### PR TITLE
Make `.ggt/sync.json` required and add --force flag

### DIFF
--- a/src/lib/base-command.ts
+++ b/src/lib/base-command.ts
@@ -60,9 +60,13 @@ export abstract class BaseCommand extends Command {
   debugEnabled = false;
 
   /**
-   * The original arguments passed to the command. Includes global flags.
+   * The selected application.
+   *
+   * Will be `undefined` if the user is not logged in or if the user has not selected an app.
+   *
+   * @see {@linkcode requireApp requireApp}
    */
-  originalArgv: string[];
+  app!: string;
 
   /**
    * Determines whether the command requires the user to be logged in or not.
@@ -98,8 +102,6 @@ export abstract class BaseCommand extends Command {
 
   constructor(argv: string[], config: Config) {
     super(argv, config);
-
-    this.originalArgv = argv;
 
     this.http = got.extend({
       hooks: {
@@ -176,6 +178,8 @@ export abstract class BaseCommand extends Command {
         choices: await this.getApps().then((apps) => apps.map((app) => app.slug)),
       }));
     }
+
+    this.app = app;
 
     this.client = new Client(app, {
       ws: {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -282,20 +282,29 @@ export class YarnNotFoundError extends BaseError {
   }
 }
 
-export class WalkedTooManyFilesError extends BaseError {
-  isBug = IsBug.NO;
+export class InvalidSyncFileError extends BaseError {
+  isBug = IsBug.MAYBE;
 
-  constructor(readonly dir: string, readonly maxFiles: number) {
-    super("GGT_CLI_TOO_MANY_FILES", "Found too many files while scanning directory");
+  constructor(override readonly cause: unknown, readonly dir: string, readonly app: string) {
+    super("GGT_CLI_INVALID_SYNC_FILE", "The .ggt/sync.json file was invalid or not found");
   }
 
-  override body(_: Config): string {
+  protected body(config: Config): string {
     return dedent`
-        The following directory has over ${this.maxFiles} non-ignored files inside of it.
+      We failed to read the Gadget metadata file in this directory:
+
         ${this.dir}
 
-        Consider adding more entries to your \`.ignore\` file.
-      `;
+      If you're running \`ggt sync\` for the first time, we recommend using an empty directory such as \`~/gadget/${this.app}\`.
+
+      Otherwise, if you're sure you want to sync the contents of \`${
+        this.dir
+      }\` to Gadget, you can run the command again with the \`--force\` flag:
+
+        $ ${config.bin} ${process.argv.slice(2).join(" ")} --force
+
+      You will be prompted to either merge your local files with your remote ones or reset your local files to your remote ones.
+    `;
   }
 }
 

--- a/src/lib/fs-utils.ts
+++ b/src/lib/fs-utils.ts
@@ -3,7 +3,6 @@ import fs from "fs-extra";
 import type { Ignore } from "ignore";
 import ignore from "ignore";
 import path from "path";
-import { WalkedTooManyFilesError } from "./errors";
 
 const debug = Debug("ggt:fs-utils");
 
@@ -38,23 +37,16 @@ export class Ignorer {
 export interface WalkDirOptions {
   ignorer?: Ignorer;
   maxFiles?: number;
-  _fileCount?: number;
-  _rootDir?: string;
 }
 
 export async function* walkDir(dir: string, options: WalkDirOptions = {}): AsyncGenerator<string> {
   if (options.ignorer?.ignores(dir)) return;
-  if (options._rootDir == null) options._rootDir = dir;
-  if (options._fileCount == null) options._fileCount = 0;
 
   for await (const entry of await fs.opendir(dir)) {
     const filepath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       yield* walkDir(filepath, options);
     } else if (entry.isFile() && !options.ignorer?.ignores(filepath)) {
-      if (options.maxFiles != null && ++options._fileCount >= options.maxFiles) {
-        throw new WalkedTooManyFilesError(options._rootDir, options.maxFiles);
-      }
       yield filepath;
     }
   }
@@ -62,20 +54,20 @@ export async function* walkDir(dir: string, options: WalkDirOptions = {}): Async
 
 export function* walkDirSync(dir: string, options: WalkDirOptions = {}): Generator<string> {
   if (options.ignorer?.ignores(dir)) return;
-  if (options._rootDir == null) options._rootDir = dir;
-  if (options._fileCount == null) options._fileCount = 0;
 
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const filepath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       yield* walkDirSync(filepath, options);
     } else if (entry.isFile() && !options.ignorer?.ignores(filepath)) {
-      if (options.maxFiles != null && ++options._fileCount >= options.maxFiles) {
-        throw new WalkedTooManyFilesError(options._rootDir, options.maxFiles);
-      }
       yield filepath;
     }
   }
+}
+
+export async function isEmptyDir(dir: string): Promise<boolean> {
+  const files = await fs.readdir(dir);
+  return files.length === 0;
 }
 
 export function ignoreEnoent(error: any): void {


### PR DESCRIPTION
This makes `ggt sync` throw an error if it can't load the `.ggt/sync.json` file in a non-empty directory. This should make it harder for users to accidentally run `ggt sync` in the wrong directory.

Before, we used to log a warning and stop if we walked too many files. This removes the need for that.

I still struggle to write clear error messages/docs so feel free to suggest changes 😄 