### PR TITLE
Save and validate `--app`

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,3 +1,4 @@
+appvalue
 commandsstop
 execa
 gadgetinc

--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@ USAGE
 
   <!-- commands -->
 
-- [`ggt sync --app <name> [DIRECTORY]`](#ggt-sync---app-name-directory)
+- [`ggt sync [--app=<value>] [DIRECTORY]`](#ggt-sync---appvalue-directory)
 - [`ggt help [COMMAND]`](#ggt-help-command)
 - [`ggt login`](#ggt-login)
 - [`ggt logout`](#ggt-logout)
 - [`ggt whoami`](#ggt-whoami)
 
-### `ggt sync --app <name> [DIRECTORY]`
+### `ggt sync [--app=<value>] [DIRECTORY]`
 
 Sync your Gadget application's source code to and from your local filesystem.
 
 ```
 USAGE
-  $ ggt sync --app <name> [DIRECTORY]
+  $ ggt sync [--app=<value>] [DIRECTORY]
 
 ARGUMENTS
   DIRECTORY  [default: .] The directory to sync files to. If the directory doesn't exist, it will be created.

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -10,6 +10,7 @@ import dedent from "ts-dedent";
 import type { SetOptional, Writable } from "type-fest";
 import { inspect } from "util";
 import type { CloseEvent, ErrorEvent } from "ws";
+import type Sync from "../commands/sync";
 import type { Payload } from "./client";
 
 /**
@@ -303,23 +304,25 @@ export class FlagError extends BaseError {
 export class InvalidSyncFileError extends BaseError {
   isBug = IsBug.MAYBE;
 
-  constructor(override readonly cause: unknown, readonly dir: string, readonly app: string) {
+  constructor(override readonly cause: unknown, readonly sync: Sync, readonly app: string | undefined) {
     super("GGT_CLI_INVALID_SYNC_FILE", "The .ggt/sync.json file was invalid or not found");
   }
 
-  protected body(config: Config): string {
+  protected body(_: Config): string {
     return dedent`
       We failed to read the Gadget metadata file in this directory:
 
-        ${this.dir}
+        ${this.sync.dir}
 
-      If you're running \`ggt sync\` for the first time, we recommend using an empty directory such as \`~/gadget/${this.app}\`.
+      If you're running \`ggt sync\` for the first time, we recommend using an empty directory such as:
 
-      Otherwise, if you're sure you want to sync the contents of \`${
-        this.dir
-      }\` to Gadget, you can run the command again with the \`--force\` flag:
+        ~/gadget/${this.app || "<name of app>"}
 
-        $ ${config.bin} ${process.argv.slice(2).join(" ")} --force
+      Otherwise, if you're sure you want to sync the contents of "${
+        this.sync.dir
+      }" to Gadget, run \`ggt sync\` again with the \`--force\` flag:
+
+        $ ggt sync ${this.sync.argv.join(" ")} --force
 
       You will be prompted to either merge your local files with your remote ones or reset your local files to your remote ones.
     `;

--- a/src/lib/fs-utils.ts
+++ b/src/lib/fs-utils.ts
@@ -65,9 +65,17 @@ export function* walkDirSync(dir: string, options: WalkDirOptions = {}): Generat
   }
 }
 
-export async function isEmptyDir(dir: string): Promise<boolean> {
-  const files = await fs.readdir(dir);
-  return files.length === 0;
+export async function isEmptyDir(dir: string, opts = { ignoreEnoent: true }): Promise<boolean> {
+  try {
+    const files = await fs.readdir(dir);
+    return files.length === 0;
+  } catch (error) {
+    if (opts.ignoreEnoent) {
+      ignoreEnoent(error);
+      return true;
+    }
+    throw error;
+  }
 }
 
 export function ignoreEnoent(error: any): void {


### PR DESCRIPTION
closes GGT-1927

This makes `ggt sync` save and remember the last `--app` it was given.

Now, if you don't provide the `--app` flag, `ggt sync` will only prompt you to select one if the directory doesn't exist or is empty. If you do provide the `--app` flag, but it doesn't match the one stored in `.ggt/sync.json`, it will exit with an error.

Example of passing a different `--app` than the one used last time:
```sh-session
$ ggt sync --app scott tmp/apps/scott
Ready
Received
← .gadget/client/dist-cjs/Client.d.ts
← .gadget/client/dist-cjs/Client.js
← .gadget/client/dist-cjs/Client.js.map
← .gadget/client/dist-cjs/iife-export.d.ts
← .gadget/client/dist-cjs/iife-export.js
← .gadget/client/dist-cjs/iife-export.js.map
← .gadget/client/dist-cjs/index.d.ts
← .gadget/client/dist-cjs/index.js
← .gadget/client/dist-cjs/index.js.map
← .gadget/client/dist-cjs/models/CurrentSession.d.ts
… 226 more
^C Stopping... (press Ctrl+C again to force)
Done

$ ggt sync --app bad-pjson tmp/apps/scott
GGT_CLI_FLAG_ERROR: Invalid value provided for the -a, --app flag

You were about to sync the following app to the following directory:

  bad-pjson → /Users/scott/Code/gadget/ggt/tmp/apps/scott

However, that directory has already been synced with this app:

  scott

If you're sure that you want to sync "bad-pjson" to "/Users/scott/Code/gadget/ggt/tmp/apps/scott", run `ggt sync` again with the `--force` flag:

  $ ggt sync --app bad-pjson tmp/apps/scott --force
```