### PR TITLE
Move `sync.json` to `.gadget`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ DESCRIPTION
 
   The following files and directories are always ignored:
     * .gadget
-    * .ggt
     * .git
     * node_modules
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -305,7 +305,7 @@ export class InvalidSyncFileError extends BaseError {
   isBug = IsBug.MAYBE;
 
   constructor(override readonly cause: unknown, readonly sync: Sync, readonly app: string | undefined) {
-    super("GGT_CLI_INVALID_SYNC_FILE", "The .ggt/sync.json file was invalid or not found");
+    super("GGT_CLI_INVALID_SYNC_FILE", "The .gadget/sync.json file was invalid or not found");
   }
 
   protected body(_: Config): string {


### PR DESCRIPTION
This moves `.ggt/sync.json` -> `.gadget/sync.json`. I don't think we need 2 separate Gadget maintained directories. I also flattened `lastWritten` since it's unnecessary and doesn't actually align with how `mtime` works.

This is technically a breaking change, so attempting to sync with an existing local dir will throw errors complaining that it can't find the `.gadget/sync.json` file. I didn't write a migration step because only the staff have been using `ggt` and we're currently in alpha.

If someone wants to migrate an existing local directory themselves, they can move `.ggt/sync.json` -> `.gadget/sync.json` and flatten `lastWritten`:
```diff
{
	"app": "scott",
-   "lastWritten": {
  	"filesVersion": "326",
  	"mtime": 1661528864319
-   }
}
```
