### PR TITLE
Use `Ignorer` for `chokidar`'s `ignored` option

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -242,13 +242,11 @@ export default class Sync extends BaseCommand {
 
     this.filePushDelay = flags["file-push-delay"];
 
-    // local files that should never be published
-    const ignored = ["node_modules/", ".gadget/", ".git/"];
-
-    this.ignorer = new Ignorer(this.dir, ignored);
+    // local files/folders that should never be published
+    this.ignorer = new Ignorer(this.dir, ["node_modules", ".gadget", ".git"]);
 
     this.watcher = new FSWatcher({
-      ignored,
+      ignored: (filepath) => this.ignorer.ignores(filepath),
       // don't emit an event for every watched file on boot
       ignoreInitial: true,
       // make sure stats are always present on add/change events


### PR DESCRIPTION
This changes the `ignored` option when instantiating `chokidar` to use our `Ignorer`.

---

I noticed the following being logged with the `--debug` flag while I was investigating #18

```
ggt:sync skipping event caused by added directory node_modules +174ms
ggt:sync skipping event caused by added directory node_modules/@fastify +27ms
ggt:sync skipping event caused by added directory node_modules/@gadget-client +0ms
ggt:sync skipping event caused by added directory node_modules/@gadgetinc +0ms
ggt:sync skipping event caused by added directory node_modules/@graphql-typed-document-node +1ms
ggt:sync skipping event caused by added directory node_modules/@opentelemetry +0ms
ggt:sync skipping event caused by added directory node_modules/@sindresorhus +0ms
ggt:sync skipping event caused by added directory node_modules/@szmarczak +0ms
ggt:sync skipping event caused by added directory node_modules/@types +0ms
ggt:sync skipping event caused by added directory node_modules/@urql +1ms
ggt:sync skipping event caused by added directory node_modules/abstract-logging +0ms
ggt:sync skipping event caused by added directory node_modules/ajv +0ms
ggt:sync skipping event caused by added directory node_modules/archy +0ms
...
```

It looks like chokidar is emitting events for file changes in the `node_modules` directory... This should never happen because we specifically ignore `node_modules` along with a few other folders when instantiating the watcher. I'm guessing that this is what was causing the memory usage to spike and cause the `JavaScript heap out of memory` issue to occur.

`chokidar` and our `Ignorer` use different syntax to ignore paths (`glob` vs `.gitignore`), so instead of trying to keep them both in sync, I'm just gonna have `chokidar` delegate to our `Ignorer`.