### PR TITLE
Only update files version if it's greater than current

### DIFF
--- a/.changeset/clever-pots-remember.md
+++ b/.changeset/clever-pots-remember.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/ggt": patch
+---
+
+Fixed `Files version mismatch` exception after reconnecting.

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -385,8 +385,11 @@ export default class Sync extends BaseCommand {
           void this.queue
             .add(async () => {
               if (!remoteFiles.size) {
-                // we still need to update filesVersion, otherwise our expectedFilesVersion will be behind the next time we publish
-                this.metadata.filesVersion = remoteFilesVersion;
+                if (BigInt(remoteFilesVersion) > BigInt(this.metadata.filesVersion)) {
+                  // we still need to update filesVersion, otherwise our expectedFilesVersion will be behind the next time we publish
+                  this.debug("updated local files version from %s to %s", this.metadata.filesVersion, remoteFilesVersion);
+                  this.metadata.filesVersion = remoteFilesVersion;
+                }
                 return;
               }
 
@@ -421,6 +424,7 @@ export default class Sync extends BaseCommand {
                 { stopOnError: false }
               );
 
+              this.debug("updated local files version from %s to %s", this.metadata.filesVersion, remoteFilesVersion);
               this.metadata.filesVersion = remoteFilesVersion;
             })
             .catch(this.stop);
@@ -475,6 +479,7 @@ export default class Sync extends BaseCommand {
             this.debug("remote files version after publishing %s", remoteFilesVersion);
 
             if (BigInt(remoteFilesVersion) > BigInt(this.metadata.filesVersion)) {
+              this.debug("updated local files version from %s to %s", this.metadata.filesVersion, remoteFilesVersion);
               this.metadata.filesVersion = remoteFilesVersion;
             }
           }

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -107,14 +107,14 @@ export class Client {
         if (this.status == ConnectionStatus.RECONNECTING) {
           // subscribePayload.variables is supposed to be readonly (it's not) and payload.variables may have been re-assigned (it won't)
           (subscribePayload as any).variables = (payload.variables as any)();
-          debug("re-sending%s", subscribePayload.query.split(" ", 2)[0], subscribePayload.query);
+          debug("re-sending %s%s%O", subscribePayload.query.split(/\s+/g, 1)[0], subscribePayload.query, subscribePayload.variables);
         }
       });
     } else {
       subscribePayload = payload as SubscribePayload;
     }
 
-    debug("sending%s", subscribePayload.query.split(/\s+/, 2)[0], subscribePayload.query);
+    debug("sending %s%s%O", subscribePayload.query.split(/\s+/g, 1)[0], subscribePayload.query, subscribePayload.variables);
     const unsubscribe = this._client.subscribe(subscribePayload, {
       next: (result: ExecutionResult<Data, Extensions>) => sink.next(result),
       error: (error) => sink.error(new ClientError(subscribePayload, error as Error | GraphQLError[] | CloseEvent | ErrorEvent)),


### PR DESCRIPTION
Fixes one of the scenarios that causes the `Files version mismatch` exception to occur.