### PR TITLE
Ignore `unlinkDir` events

### DIFF
--- a/.changeset/shiny-days-join.md
+++ b/.changeset/shiny-days-join.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/ggt": patch
+---
+
+Ignore `unlinkDir` events

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -493,8 +493,8 @@ export default class Sync extends BaseCommand {
       .on("all", (event, filepath, stats) => {
         const relativePath = this.relative(filepath);
 
-        if (event === "addDir") {
-          this.debug("skipping event caused by added directory %s", relativePath);
+        if (event === "addDir" || event === "unlinkDir") {
+          this.debug("skipping event caused by directory %s", relativePath);
           return;
         }
 
@@ -530,7 +530,6 @@ export default class Sync extends BaseCommand {
             localFilesBuffer.set(filepath, { mode: stats.mode, mtime: stats.mtime.getTime() });
             break;
           case "unlink":
-          case "unlinkDir":
             localFilesBuffer.set(filepath, false);
             break;
         }


### PR DESCRIPTION
`unlinkDir` events are redundant because all the files in the deleted directory also emit `unlink` events.