### PR TITLE
Add Gadget specific domains to context

### DIFF
--- a/spec/jest.setup.ts
+++ b/spec/jest.setup.ts
@@ -18,6 +18,8 @@ export function testDirPath(): string {
 }
 
 beforeEach(async () => {
+  process.env["GGT_ENV"] = "test";
+
   debug("starting test %o", { test: expect.getState().currentTestName, path: expect.getState().testPath });
 
   const testDir = testDirPath();

--- a/spec/utils/base-command.spec.ts
+++ b/spec/utils/base-command.spec.ts
@@ -5,7 +5,7 @@ import { prompt } from "inquirer";
 import { noop } from "lodash";
 import open from "open";
 import { BaseCommand } from "../../src/utils/base-command";
-import { context, GADGET_ENDPOINT } from "../../src/utils/context";
+import { context } from "../../src/utils/context";
 import { sleepUntil } from "../../src/utils/sleep";
 
 class Base extends BaseCommand<typeof Base> {
@@ -104,7 +104,9 @@ describe("BaseCommand", () => {
       expect(requestListener!).toBeDefined();
       expect(server.listen).toHaveBeenCalledWith(port);
       expect(open).toHaveBeenCalledWith(
-        `${GADGET_ENDPOINT}/auth/login?returnTo=${encodeURIComponent(`${GADGET_ENDPOINT}/auth/cli/callback?port=${port}`)}`
+        `https://${context.domains.services}/auth/login?returnTo=${encodeURIComponent(
+          `https://${context.domains.services}/auth/cli/callback?port=${port}`
+        )}`
       );
       expect(base.log.mock.lastCall?.[0]).toMatchInlineSnapshot(`
         "We've opened Gadget's login page using your default browser.
@@ -130,7 +132,7 @@ describe("BaseCommand", () => {
       expect(context.session).toBe("test");
       expect(context.getUser).toHaveBeenCalled();
       expect(base.log.mock.lastCall?.[0]).toMatchInlineSnapshot(`"Hello, Jane Doe (test@example.com)"`);
-      expect(res.writeHead).toHaveBeenCalledWith(303, { Location: `${GADGET_ENDPOINT}/auth/cli?success=true` });
+      expect(res.writeHead).toHaveBeenCalledWith(303, { Location: `https://${context.domains.services}/auth/cli?success=true` });
       expect(res.end).toHaveBeenCalled();
       expect(server.close).toHaveBeenCalled();
     });
@@ -146,7 +148,9 @@ describe("BaseCommand", () => {
       expect(requestListener!).toBeDefined();
       expect(server.listen).toHaveBeenCalledWith(port);
       expect(open).toHaveBeenCalledWith(
-        `${GADGET_ENDPOINT}/auth/login?returnTo=${encodeURIComponent(`${GADGET_ENDPOINT}/auth/cli/callback?port=${port}`)}`
+        `https://${context.domains.services}/auth/login?returnTo=${encodeURIComponent(
+          `https://${context.domains.services}/auth/cli/callback?port=${port}`
+        )}`
       );
       expect(base.log.mock.lastCall?.[0]).toMatchInlineSnapshot(`
         "We've opened Gadget's login page using your default browser.
@@ -171,7 +175,7 @@ describe("BaseCommand", () => {
       await sleepUntil(() => server.close.mock.calls.length > 0);
       expect(context.session).toBeUndefined();
       expect(context.getUser).toHaveBeenCalled();
-      expect(res.writeHead).toHaveBeenCalledWith(303, { Location: `${GADGET_ENDPOINT}/auth/cli?success=false` });
+      expect(res.writeHead).toHaveBeenCalledWith(303, { Location: `https://${context.domains.services}/auth/cli?success=false` });
       expect(res.end).toHaveBeenCalled();
       expect(server.close).toHaveBeenCalled();
     });

--- a/spec/utils/context.spec.ts
+++ b/spec/utils/context.spec.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import fs from "fs-extra";
-import { context, GADGET_ENDPOINT } from "../../src/utils/context";
+import { context } from "../../src/utils/context";
 import nock from "nock";
 
 describe("Context", () => {
@@ -55,7 +55,7 @@ describe("Context", () => {
   describe("getUser", () => {
     it("returns the user if the session is set", async () => {
       const user = { email: "test@example.com", name: "Jane Doe" };
-      nock(GADGET_ENDPOINT).get("/auth/api/current-user").reply(200, user);
+      nock(`https://${context.domains.services}`).get("/auth/api/current-user").reply(200, user);
       context.session = "test";
 
       await expect(context.getUser()).resolves.toEqual(user);
@@ -69,7 +69,7 @@ describe("Context", () => {
 
     it("returns undefined if the session is invalid or expired", async () => {
       context.session = "test";
-      nock(GADGET_ENDPOINT).get("/auth/api/current-user").reply(401);
+      nock(`https://${context.domains.services}`).get("/auth/api/current-user").reply(401);
 
       await expect(context.getUser()).resolves.toBeUndefined();
       expect(nock.isDone()).toBe(true);
@@ -78,7 +78,7 @@ describe("Context", () => {
 
     it("caches the user", async () => {
       const user = { email: "test@example.com", name: "Jane Doe" };
-      nock(GADGET_ENDPOINT).get("/auth/api/current-user").reply(200, user);
+      nock(`https://${context.domains.services}`).get("/auth/api/current-user").reply(200, user);
       context.session = "test";
 
       await expect(context.getUser()).resolves.toEqual(user);
@@ -93,7 +93,7 @@ describe("Context", () => {
   describe("getAvailableApps", () => {
     it("returns the available apps if the session is set", async () => {
       const apps = [{ id: 1, name: "Test App" }];
-      nock(GADGET_ENDPOINT).get("/auth/api/apps").reply(200, apps);
+      nock(`https://${context.domains.services}`).get("/auth/api/apps").reply(200, apps);
 
       context.session = "test";
 
@@ -108,7 +108,7 @@ describe("Context", () => {
 
     it("caches the available apps", async () => {
       const apps = [{ id: 1, name: "Test App" }];
-      nock(GADGET_ENDPOINT).get("/auth/api/apps").reply(200, apps);
+      nock(`https://${context.domains.services}`).get("/auth/api/apps").reply(200, apps);
       context.session = "test";
 
       await expect(context.getAvailableApps()).resolves.toEqual(apps);

--- a/spec/utils/context.spec.ts
+++ b/spec/utils/context.spec.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import fs from "fs-extra";
-import { context } from "../../src/utils/context";
+import { Context, context } from "../../src/utils/context";
 import nock from "nock";
 
 describe("Context", () => {
@@ -117,6 +117,47 @@ describe("Context", () => {
         expect(nock.isDone()).toBeTrue();
         await expect(context.getAvailableApps()).resolves.toEqual(apps);
       }
+    });
+  });
+
+  describe("domains", () => {
+    afterEach(() => {
+      delete process.env["GGT_GADGET_APP_DOMAIN"];
+      delete process.env["GGT_GADGET_SERVICES_DOMAIN"];
+    });
+
+    describe("app", () => {
+      it("uses GGT_GADGET_APP_DOMAIN if set", () => {
+        const domain = "test.example.com";
+        process.env["GGT_GADGET_APP_DOMAIN"] = domain;
+        expect(new Context().domains.app).toBe(domain);
+      });
+
+      it("defaults to gadget.app when GGT_ENV is production", () => {
+        process.env["GGT_ENV"] = "production";
+        expect(new Context().domains.app).toBe("gadget.app");
+      });
+
+      it("defaults to ggt.pub otherwise", () => {
+        expect(new Context().domains.app).toBe("ggt.pub");
+      });
+    });
+
+    describe("services", () => {
+      it("uses GGT_GADGET_SERVICES_DOMAIN if set", () => {
+        const domain = "test.example.com";
+        process.env["GGT_GADGET_SERVICES_DOMAIN"] = domain;
+        expect(new Context().domains.services).toBe(domain);
+      });
+
+      it("defaults to app.gadget.dev when GGT_ENV is production", () => {
+        process.env["GGT_ENV"] = "production";
+        expect(new Context().domains.services).toBe("app.gadget.dev");
+      });
+
+      it("defaults to app.ggt.dev otherwise", () => {
+        expect(new Context().domains.services).toBe("app.ggt.dev");
+      });
     });
   });
 });

--- a/src/utils/base-command.ts
+++ b/src/utils/base-command.ts
@@ -17,7 +17,7 @@ import type WindowsToaster from "node-notifier/notifiers/toaster";
 import open from "open";
 import path from "path";
 import dedent from "ts-dedent";
-import { context, GADGET_ENDPOINT } from "./context";
+import { context } from "./context";
 import { BaseError, UnexpectedError as UnknownError } from "./errors";
 
 export type Flags<T extends typeof Command> = Interfaces.InferredFlags<(typeof BaseCommand)["baseFlags"] & T["flags"]>;
@@ -146,7 +146,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       const receiveSession = new Promise<void>((resolve, reject) => {
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         server = createServer(async (req, res) => {
-          const redirectTo = new URL(`${GADGET_ENDPOINT}/auth/cli`);
+          const redirectTo = new URL(`https://${context.domains.services}/auth/cli`);
 
           try {
             if (!req.url) throw new Error("missing url");
@@ -181,8 +181,8 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
         server.listen(port);
       });
 
-      const url = new URL(`${GADGET_ENDPOINT}/auth/login`);
-      url.searchParams.set("returnTo", `${GADGET_ENDPOINT}/auth/cli/callback?port=${port}`);
+      const url = new URL(`https://${context.domains.services}/auth/login`);
+      url.searchParams.set("returnTo", `https://${context.domains.services}/auth/cli/callback?port=${port}`);
       await open(url.toString());
 
       this.log(dedent`

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -27,10 +27,9 @@ export class Client {
 
   constructor() {
     assert(context.app, "context.app must be set before instantiating the Client");
-    const domain = context.env.productionLike ? "gadget.app" : "ggt.pub:3000";
 
     this._client = createClient({
-      url: `wss://${context.app.slug}.${domain}/edit/api/graphql-ws`,
+      url: `wss://${context.app.slug}.${context.domains.app}/edit/api/graphql-ws`,
       shouldRetry: () => true,
       webSocketImpl: class extends WebSocket {
         constructor(address: string | URL, protocols?: string | string[], wsOptions?: WebSocket.ClientOptions | ClientRequestArgs) {

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -6,7 +6,7 @@ import { isString } from "lodash";
 import path from "path";
 import { ignoreEnoent } from "./fs-utils";
 
-class Context {
+export class Context {
   /**
    * A reference to oclif's {@linkcode Config}.
    *
@@ -45,8 +45,8 @@ class Context {
 
   constructor() {
     this.domains = {
-      app: process.env["GGT_GADGET_APP_DOMAIN"] || this.env.productionLike ? "gadget.app" : "ggt.pub",
-      services: process.env["GGT_GADGET_SERVICES_DOMAIN"] || this.env.productionLike ? "app.gadget.dev" : "app.ggt.dev",
+      app: process.env["GGT_GADGET_APP_DOMAIN"] || (this.env.productionLike ? "gadget.app" : "ggt.pub"),
+      services: process.env["GGT_GADGET_SERVICES_DOMAIN"] || (this.env.productionLike ? "app.gadget.dev" : "app.ggt.dev"),
     };
   }
 


### PR DESCRIPTION
Points our development gadget domains to the new urls without the ports and adds the ability to overwrite the gadget domains with environment variables.