### PR TITLE
Await finishing using a promise instead of polling state

### DIFF
--- a/.changeset/pink-clocks-flow.md
+++ b/.changeset/pink-clocks-flow.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/ggt": patch
+---
+
+Avoid high-cpu usage from overly-aggressive internal polling


### PR DESCRIPTION
Fixes #209 and #298

Previously, we were using the sleepUntil utility to await the end state of the sync before quitting. sleepUntil loops internally with a sleep(0), which uses a lot of CPU! This updates us to use a promise that we manually resolve instead, which means the node process can actually sleep while nothing is happening. 
CPU profile before:
![CleanShot 2023-03-04 at 15 23 54@2x](https://user-images.githubusercontent.com/158950/222927169-6310ad78-a95d-4e80-a64f-f40b56fd1946.png)

CPU profile after:


![CleanShot 2023-03-04 at 15 24 18@2x](https://user-images.githubusercontent.com/158950/222927186-e569ffbf-cffe-44d6-b479-4c1bdff1c580.png)
