### PR TITLE
Allow empty folders to be synced to gadget and vice versa

### DIFF
--- a/.changeset/sweet-radios-listen.md
+++ b/.changeset/sweet-radios-listen.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/ggt": patch
+---
+
+Allow empty folders to be synced to gadget and vice versa

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,8 @@
               };
 
               nodejs = pkgs.nodejs-16_x;
+
+              mkcert = pkgs.mkcert;
             };
 
           devShell = pkgs.mkShell {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint": "concurrently --prefix none --group 'npm:lint:*'",
     "lint:cspell": "cspell --no-progress --show-suggestions --show-context '**'",
     "lint:eslint": "eslint --max-warnings 0 .",
+    "lint:fix": "prettier --write . && eslint --fix .",
     "lint:prettier": "prettier --check .",
     "lint:typescript": "tsc --project tsconfig.json --project spec/tsconfig.json --noEmit",
     "publish": "npm run build && changeset publish",


### PR DESCRIPTION
This PR adds support for syncing empty directories to Gadget and vice versa. Many of the changes are related to detecting directories and ensuring that their paths always end with a trailing slash. Syncing the directories to Gadget seem to work fine with the local fs mode, but when syncing from Gadget we set the mode to `0o755` which is what we currently do for directories that contain files