### PR TITLE
Ignore `this.exit(0)` errors

### DIFF
--- a/.changeset/nine-apes-swim.md
+++ b/.changeset/nine-apes-swim.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/ggt": patch
+---
+
+Ignore `this.exit(0)` errors

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "/README.md"
   ],
   "scripts": {
-    "build": "rimraf lib && tsc --build && oclif manifest",
+    "build": "npm run clean && tsc --build && oclif manifest",
+    "clean": "rimraf lib tmp oclif.manifest.json",
     "generate-graphql": "graphql-codegen --config graphql-codegen.yml",
     "lint": "concurrently --prefix none --group 'npm:lint:*'",
     "lint:cspell": "cspell --no-progress --show-suggestions --show-context '**'",

--- a/spec/utils/base-command.spec.ts
+++ b/spec/utils/base-command.spec.ts
@@ -7,6 +7,9 @@ import open from "open";
 import { BaseCommand } from "../../src/utils/base-command";
 import { context } from "../../src/utils/context";
 import { sleepUntil } from "../../src/utils/sleep";
+import { ExitError } from "@oclif/errors";
+import { BaseError } from "../../src/utils/errors";
+import { getError } from "../util";
 
 class Base extends BaseCommand<typeof Base> {
   run = jest.fn();
@@ -178,6 +181,17 @@ describe("BaseCommand", () => {
       expect(res.writeHead).toHaveBeenCalledWith(303, { Location: `https://${context.domains.services}/auth/cli?success=false` });
       expect(res.end).toHaveBeenCalled();
       expect(server.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("catch", () => {
+    it("immediately rethrows ExitError with a 0 exit code", async () => {
+      const spy = jest.spyOn(BaseError.prototype, "capture");
+      const error = await getError(() => base.catch(new ExitError(0)));
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(error).toBeInstanceOf(ExitError);
+      expect(error.oclif.exit).toBe(0);
     });
   });
 });

--- a/src/utils/base-command.ts
+++ b/src/utils/base-command.ts
@@ -201,7 +201,12 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
    * Overrides the default `catch` behavior so we can control how errors are printed to the user. This is called automatically by oclif when
    * an error is thrown during the `init` or `run` methods.
    */
-  override async catch(cause: Error & { exitCode?: number }): Promise<never> {
+  override async catch(cause: Error & { oclif?: { exit: number } }): Promise<never> {
+    if (cause.oclif?.exit === 0) {
+      // we called `this.exit(0)` so we're not actually exiting with an error
+      throw cause;
+    }
+
     const error = cause instanceof BaseError ? cause : new UnknownError(cause);
     console.error(error.render());
     await error.capture();
@@ -212,6 +217,6 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     //
     //  catch: https://github.com/oclif/core/blob/12e31ff2288606e583e03bf774a3244f3136cd10/src/command.ts#L261
     // handle: https://github.com/oclif/core/blob/12e31ff2288606e583e03bf774a3244f3136cd10/src/errors/handle.ts#L15
-    throw new ExitError(process.exitCode ?? cause.exitCode ?? 1);
+    throw new ExitError(process.exitCode ?? cause.oclif?.exit ?? 1);
   }
 }


### PR DESCRIPTION
When we call `this.exit(0)` [here](https://github.com/gadget-inc/ggt/blob/sc/handle-exit-0/src/utils/base-command.ts#L87), it throws the following error:

```
GGT_CLI_UNEXPECTED_ERROR: An unexpected error occurred

Error: EEXIT: 0
    at Object.exit (/Users/scott/Code/gadget/ggt/node_modules/@oclif/core/lib/errors/index.js:21:11)
    at Sync.exit (/Users/scott/Code/gadget/ggt/node_modules/@oclif/core/lib/command.js:122:23)
    at Sync.init (/Users/scott/Code/gadget/ggt/lib/utils/base-command.js:70:29)
    at async Sync.init (/Users/scott/Code/gadget/ggt/lib/commands/sync.js:143:9)
    at async Sync._run (/Users/scott/Code/gadget/ggt/node_modules/@oclif/core/lib/command.js:107:13)
    at async Config.runCommand (/Users/scott/Code/gadget/ggt/node_modules/@oclif/core/lib/config/config.js:328:25)
    at async Object.run (/Users/scott/Code/gadget/ggt/node_modules/@oclif/core/lib/main.js:89:16)
```

Exiting with code `0` isn't an error, so this PR ignores it.