### PR TITLE
Fix auto login

### DIFF
--- a/.changeset/happy-queens-crash.md
+++ b/.changeset/happy-queens-crash.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/ggt": patch
+---
+
+Fix `ggt sync` auto login feature


### PR DESCRIPTION
When someone runs `ggt sync --app foo`, we make sure they actually have an app named `foo` by making a request to Gadget. If you have an app named `foo` and you're logged in, all good 👍 

However, if you're not logged in, we consider you to have no apps which means that `ggt sync` will always respond with the following error:

```
GGT_CLI_FLAG_ERROR: Invalid value provided for the -a, --app flag

Unknown application:

  foo

It doesn't look like you have any applications.

Visit https://gadget.new to create one!
```

Sync automatically logs you in if you're not already, but before this PR we logged you in **after** parsing flags 🤦 

This PR makes us log you in before parsing flags so we can actually check which apps you have.