### PR TITLE
Don't include root directory in `getChangedFiles`

### DIFF
--- a/.changeset/thick-students-cry.md
+++ b/.changeset/thick-students-cry.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/ggt": patch
+---
+
+Don't include root directory in `getChangedFiles`

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -283,6 +283,10 @@ export default class Sync extends BaseCommand<typeof Sync> {
           files.set(this.absolute(filepath), stats);
         }
       }
+
+      // don't include the root directory
+      files.delete(this.dir);
+
       return files;
     };
 

--- a/src/utils/fs-utils.ts
+++ b/src/utils/fs-utils.ts
@@ -36,15 +36,12 @@ export class Ignorer {
 
 export interface WalkDirOptions {
   ignorer?: Ignorer;
-  maxFiles?: number;
 }
 
 export async function* walkDir(dir: string, options: WalkDirOptions = {}): AsyncGenerator<string> {
   if (options.ignorer?.ignores(dir)) return;
 
-  const isEmpty = await isEmptyDir(dir);
-
-  if (isEmpty) {
+  if (await isEmptyDir(dir)) {
     yield `${dir}/`;
     return;
   }
@@ -62,9 +59,7 @@ export async function* walkDir(dir: string, options: WalkDirOptions = {}): Async
 export function* walkDirSync(dir: string, options: WalkDirOptions = {}): Generator<string> {
   if (options.ignorer?.ignores(dir)) return;
 
-  const isEmpty = isEmptyDirSync(dir);
-
-  if (isEmpty) {
+  if (isEmptyDirSync(dir)) {
     yield `${dir}/`;
     return;
   }


### PR DESCRIPTION
When we syncing for the first time, we create an empty directory if one doesn't already exist. This empty directory shouldn't be included in the list of "changed files" when booting up.