### PR TITLE
Don't use `fs.readFile` on directories

### DIFF
--- a/.changeset/chilly-steaks-smash.md
+++ b/.changeset/chilly-steaks-smash.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/ggt": patch
+---
+
+Don't use `fs.readFile` on directories

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -179,7 +179,7 @@ export default class Sync extends BaseCommand<typeof Sync> {
   }
 
   normalize(filepath: string, isDirectory = false): string {
-    return normalizePath(`${path.isAbsolute(filepath) ? this.relative(filepath) : filepath}${isDirectory ? "/" : ""}`, false);
+    return normalizePath(path.isAbsolute(filepath) ? this.relative(filepath) : filepath) + (isDirectory ? "/" : "");
   }
 
   logPaths(prefix: string, changed: string[], deleted: string[], { limit = 10 } = {}): void {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -326,10 +326,12 @@ export default class Sync extends BaseCommand<typeof Sync> {
                   this.metadata.mtime = stats.mtime.getTime();
                 }
 
+                const isDirectory = stats.isDirectory();
+
                 return {
-                  path: this.normalize(filepath),
+                  path: this.normalize(filepath, isDirectory),
                   mode: stats.mode,
-                  content: await fs.readFile(filepath, "base64"),
+                  content: isDirectory ? "" : await fs.readFile(filepath, "base64"),
                   encoding: FileSyncEncoding.Base64,
                 };
               }),


### PR DESCRIPTION
`fs.readFile` doesn't work when the given path is a directory and rejects with:

```
EISDIR: illegal operation on a directory, read
```

We check to make sure the path isn't a directory when a file changes, but forgot to check when booting up 🤦 -- this fixes that.

Fixes: #409 