### PR TITLE
Don't send parent directories back to Gadget

### DIFF
--- a/.changeset/tiny-ants-rule.md
+++ b/.changeset/tiny-ants-rule.md
@@ -1,0 +1,5 @@
+---
+"@gadgetinc/ggt": patch
+---
+
+Don't send parent directories back to Gadget


### PR DESCRIPTION
Fixes the following issue:

```
Received 3:28:11 PM
← routes/GET.js (changed)
← util/files.js (changed)
3 files in total. 3 changed, 0 deleted.

Sent 3:28:12 PM
→ routes/ (changed)
→ util/ (changed)
2 files in total. 2 changed, 0 deleted.
```