### PR TITLE
Use `ggt` instead of `@gadgetinc/ggt`

### DIFF
--- a/.changeset/pink-crabs-bake.md
+++ b/.changeset/pink-crabs-bake.md
@@ -1,0 +1,7 @@
+---
+"ggt": patch
+---
+
+We got access to the [`ggt`](https://www.npmjs.com/package/ggt) npm package! 🎉
+
+This changes our package.json's name to `ggt` so we can start using it. We're still going to publish new versions to `@gadgetinc/ggt` while we update our docs and give folks time to move over.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,6 +40,17 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - if: steps.changesets.outputs.published == 'true'
+        name: Publish to @gadgetinc/ggt
+        run: |
+          jq '.name = "@gadgetinc/ggt"' package.json >package.json.tmp
+          mv package.json.tmp package.json
+          npm install --package-lock-only
+          npm run publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - if: steps.changesets.outputs.published == 'true'
         name: Create Sentry release
         uses: getsentry/action-release@v1
         with:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,11 @@
 {
-  "name": "@gadgetinc/ggt",
+  "name": "ggt",
   "version": "0.1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@gadgetinc/ggt",
+      "name": "ggt",
       "version": "0.1.18",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gadgetinc/ggt",
+  "name": "ggt",
   "version": "0.1.18",
   "description": "The command-line interface for Gadget",
   "homepage": "https://github.com/gadget-inc/ggt",


### PR DESCRIPTION
We got access to the [`ggt`](https://www.npmjs.com/package/ggt) npm package! 🎉 

This changes our package.json's name to `ggt` so we can start using it. We're still going to publish new versions to `@gadgetinc/ggt` while we come up with a strategy to move people over.
