### PR TITLE
Switch to using `watcher` instead of `chokidar` to support renames

### DIFF
--- a/.changeset/gold-countries-reflect.md
+++ b/.changeset/gold-countries-reflect.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Support rename propagation when using file sync and switch to using `watcher` instead of `chokidar`

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 node_modules
 oclif.manifest.json
 tmp
+*.orig

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,7 +17,6 @@
         "@swc/helpers": "^0.5.1",
         "chalk": "^5.2.0",
         "chalk-template": "^1.1.0",
-        "chokidar": "^3.5.3",
         "clean-stack": "^5.2.0",
         "date-fns": "^2.30.0",
         "debug": "^4.3.4",
@@ -39,6 +38,7 @@
         "pluralize": "^8.0.0",
         "serialize-error": "^11.0.0",
         "ts-dedent": "^2.2.0",
+        "watcher": "^2.2.2",
         "which": "^3.0.1",
         "ws": "^8.13.0"
       },
@@ -6370,7 +6370,10 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -6947,7 +6950,10 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7415,6 +7421,7 @@
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -7422,6 +7429,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -8643,6 +8652,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dettle": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dettle/-/dettle-1.0.1.tgz",
+      "integrity": "sha512-/oD3At60ZfhgzpofJtyClNTrIACyMdRe+ih0YiHzAniN0IZnLdLpEzgR6RtGs3kowxUkTnvV/4t1FBxXMUdusQ=="
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -9961,6 +9975,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10953,7 +10968,10 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -14427,6 +14445,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/glob/node_modules/minipass": {
+      "version": "6.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
@@ -18268,7 +18295,10 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -18555,6 +18585,14 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ripstat": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripstat/-/ripstat-2.0.2.tgz",
+      "integrity": "sha512-93g4yBvHzYwl9issdCObsHBojarat+rGT4QDFR0gFrOO4UrG90XUufMGkaSCn21awp08ahP/mQlqIiVFsTH8LQ==",
+      "dependencies": {
+        "stubborn-fs": "^1.2.4"
       }
     },
     "node_modules/rollup": {
@@ -19638,6 +19676,11 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/stubborn-fs": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
+      "integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w=="
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "license": "MIT",
@@ -19795,6 +19838,11 @@
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
       }
+    },
+    "node_modules/tiny-readdir": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-readdir/-/tiny-readdir-2.2.0.tgz",
+      "integrity": "sha512-bO4IgID5M2x5YQFBru/wREgT30YuA8aoOd/F8Rd6LKRIn1gOe9aREjT74J9EVukHqI/2RB+4SM1RgXM0gwxoWw=="
     },
     "node_modules/tinybench": {
       "version": "2.5.0",
@@ -20679,6 +20727,16 @@
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-1.0.0.tgz",
       "integrity": "sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==",
       "dev": true
+    },
+    "node_modules/watcher": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/watcher/-/watcher-2.2.2.tgz",
+      "integrity": "sha512-q6H+WoyFUtcKbOiMh8HqtHqv8qMbJdAunALRyp3/Iwi/8vEBZ86AV71vTcbiX1JrtvbM2FeqQTFrXLIs9jT7EQ==",
+      "dependencies": {
+        "dettle": "^1.0.1",
+        "ripstat": "^2.0.0",
+        "tiny-readdir": "^2.2.0"
+      }
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
@@ -26306,6 +26364,9 @@
     },
     "anymatch": {
       "version": "3.1.2",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -26719,7 +26780,10 @@
       }
     },
     "binary-extensions": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "binaryextensions": {
       "version": "4.18.0",
@@ -27062,6 +27126,9 @@
     },
     "chokidar": {
       "version": "3.5.3",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -27938,6 +28005,11 @@
     "detect-indent": {
       "version": "6.1.0",
       "dev": true
+    },
+    "dettle": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dettle/-/dettle-1.0.1.tgz",
+      "integrity": "sha512-/oD3At60ZfhgzpofJtyClNTrIACyMdRe+ih0YiHzAniN0IZnLdLpEzgR6RtGs3kowxUkTnvV/4t1FBxXMUdusQ=="
     },
     "dezalgo": {
       "version": "1.0.4",
@@ -28926,6 +28998,7 @@
     },
     "fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -29619,6 +29692,9 @@
     },
     "is-binary-path": {
       "version": "2.1.0",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -31689,6 +31765,13 @@
             "minimatch": "^9.0.0",
             "minipass": "^5.0.0 || ^6.0.0",
             "path-scurry": "^1.7.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "graceful-fs": {
@@ -34664,6 +34747,9 @@
     },
     "readdirp": {
       "version": "3.6.0",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -34865,6 +34951,14 @@
           "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
           "dev": true
         }
+      }
+    },
+    "ripstat": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripstat/-/ripstat-2.0.2.tgz",
+      "integrity": "sha512-93g4yBvHzYwl9issdCObsHBojarat+rGT4QDFR0gFrOO4UrG90XUufMGkaSCn21awp08ahP/mQlqIiVFsTH8LQ==",
+      "requires": {
+        "stubborn-fs": "^1.2.4"
       }
     },
     "rollup": {
@@ -35657,6 +35751,11 @@
         "peek-readable": "^5.0.0"
       }
     },
+    "stubborn-fs": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
+      "integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w=="
+    },
     "supports-color": {
       "version": "8.1.1",
       "requires": {
@@ -35767,6 +35866,11 @@
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
       }
+    },
+    "tiny-readdir": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-readdir/-/tiny-readdir-2.2.0.tgz",
+      "integrity": "sha512-bO4IgID5M2x5YQFBru/wREgT30YuA8aoOd/F8Rd6LKRIn1gOe9aREjT74J9EVukHqI/2RB+4SM1RgXM0gwxoWw=="
     },
     "tinybench": {
       "version": "2.5.0",
@@ -36359,6 +36463,16 @@
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-1.0.0.tgz",
       "integrity": "sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==",
       "dev": true
+    },
+    "watcher": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/watcher/-/watcher-2.2.2.tgz",
+      "integrity": "sha512-q6H+WoyFUtcKbOiMh8HqtHqv8qMbJdAunALRyp3/Iwi/8vEBZ86AV71vTcbiX1JrtvbM2FeqQTFrXLIs9jT7EQ==",
+      "requires": {
+        "dettle": "^1.0.1",
+        "ripstat": "^2.0.0",
+        "tiny-readdir": "^2.2.0"
+      }
     },
     "wcwidth": {
       "version": "1.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14447,15 +14447,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/glob/node_modules/minipass": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
@@ -31765,13 +31756,6 @@
             "minimatch": "^9.0.0",
             "minipass": "^5.0.0 || ^6.0.0",
             "path-scurry": "^1.7.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
         "graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@swc/helpers": "^0.5.1",
     "chalk": "^5.2.0",
     "chalk-template": "^1.1.0",
-    "chokidar": "^3.5.3",
     "clean-stack": "^5.2.0",
     "date-fns": "^2.30.0",
     "debug": "^4.3.4",
@@ -67,6 +66,7 @@
     "pluralize": "^8.0.0",
     "serialize-error": "^11.0.0",
     "ts-dedent": "^2.2.0",
+    "watcher": "^2.2.2",
     "which": "^3.0.1",
     "ws": "^8.13.0"
   },

--- a/spec/commands/sync.spec.ts
+++ b/spec/commands/sync.spec.ts
@@ -1,4 +1,4 @@
-import { FSWatcher } from "chokidar";
+import { default as FSWatcher } from "watcher";
 import { execa } from "execa";
 import type { Stats } from "fs-extra";
 import fs from "fs-extra";
@@ -7,7 +7,6 @@ import inquirer from "inquirer";
 import _ from "lodash";
 import notifier from "node-notifier";
 import path from "path";
-import type { SetRequired } from "type-fest";
 import which from "which";
 import Sync, {
   Action,
@@ -36,20 +35,25 @@ describe("Sync", () => {
   let dir: string;
   let app: string;
   let sync: Sync;
+  let oldFileStats: (filepath: string) => Stats;
 
   const emit: {
     all: (
-      eventName: "add" | "addDir" | "change" | "unlink" | "unlinkDir",
+      eventName: "add" | "addDir" | "change" | "unlink" | "unlinkDir" | "rename" | "renameDir",
       path: string,
-      stats?: SetRequired<Partial<Stats>, "mode" | "mtime">
+      renamedPath?: string
     ) => void;
     error: (error: unknown) => void;
+    close: () => void;
   } = {
     all: undefined as any,
     error: undefined as any,
+    close: undefined as any,
   };
 
   beforeEach(() => {
+    oldFileStats = Sync.fileStats;
+    Sync.fileStats = vi.fn().mockImplementation(() => stats) as (filepath: string) => Stats;
     client = mockClient();
     dir = path.join(testDirPath(), "app");
     app = "test";
@@ -62,9 +66,8 @@ describe("Sync", () => {
     ]);
 
     // TODO: we don't need to mock the watcher anymore since we're using the real filesystem
-    vi.spyOn(FSWatcher.prototype, "add").mockReturnThis();
     vi.spyOn(FSWatcher.prototype, "close").mockImplementation(_.noop as any);
-    vi.spyOn(FSWatcher.prototype, "on").mockImplementation(function (this: FSWatcher, eventName, handler) {
+    vi.spyOn(Sync.prototype, "on").mockImplementation(function (this: Sync, eventName, handler) {
       switch (eventName) {
         case "all":
           emit.all = handler;
@@ -72,11 +75,13 @@ describe("Sync", () => {
         case "error":
           emit.error = handler;
           break;
-        default:
-          throw new Error(`Unhandled eventName: ${eventName}`);
       }
       return this;
     });
+  });
+
+  afterEach(() => {
+    Sync.fileStats = oldFileStats;
   });
 
   it("requires a user to be logged in", () => {
@@ -650,7 +655,7 @@ describe("Sync", () => {
 
       it("writes deletes before changes", async () => {
         await setupDir(dir, {
-          "foo/": "",
+          "foo/": {},
         });
 
         client._subscription(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION).sink.next({
@@ -697,9 +702,9 @@ describe("Sync", () => {
 
           await sleepUntil(() => sync.state.filesVersion == 1n);
 
-          emit.all("change", path.join(dir, "file1.js"), stats);
-          emit.all("change", path.join(dir, "file2.js"), stats);
-          emit.all("change", path.join(dir, "file3.js"), stats);
+          emit.all("change", path.join(dir, "file1.js"));
+          emit.all("change", path.join(dir, "file2.js"));
+          emit.all("change", path.join(dir, "file3.js"));
 
           await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
 
@@ -800,8 +805,8 @@ describe("Sync", () => {
           "some/deeply/nested/file.js": "bar",
         });
 
-        emit.all("add", path.join(dir, "file.js"), stats);
-        emit.all("change", path.join(dir, "some/deeply/nested/file.js"), stats);
+        emit.all("add", path.join(dir, "file.js"));
+        emit.all("change", path.join(dir, "some/deeply/nested/file.js"));
 
         await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
         client._subscription(PUBLISH_FILE_SYNC_EVENTS_MUTATION).sink.next({ data: { publishFileSyncEvents: { remoteFilesVersion: "1" } } });
@@ -818,9 +823,40 @@ describe("Sync", () => {
         });
       });
 
+      it("publishes change event on rename events", async () => {
+        // we setup the directory as it would be after the rename because we read file contents of the new file path
+        await setupDir(dir, {
+          "bar/": {
+            "bar1.js": "foo1",
+            "bar2.js": "foo2",
+          },
+          "bar.js": "bar",
+          "baz.js": "baz",
+        });
+
+        emit.all("renameDir", path.join(dir, "foo/"), path.join(dir, "bar/"));
+        emit.all("rename", path.join(dir, "foo/foo1.js"), path.join(dir, "bar/bar1.js"));
+        emit.all("rename", path.join(dir, "foo/foo2.js"), path.join(dir, "bar/bar2.js"));
+
+        await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
+        client._subscription(PUBLISH_FILE_SYNC_EVENTS_MUTATION).sink.next({ data: { publishFileSyncEvents: { remoteFilesVersion: "1" } } });
+
+        expect(client._subscription(PUBLISH_FILE_SYNC_EVENTS_MUTATION).payload.variables).toEqual({
+          input: {
+            expectedRemoteFilesVersion: String(sync.state.filesVersion),
+            changed: expect.arrayContaining([
+              { path: "bar/", content: toBase64(""), mode: 420, encoding: FileSyncEncoding.Base64, oldPath: "foo/" },
+              { path: "bar/bar1.js", content: toBase64("foo1"), mode: 420, encoding: FileSyncEncoding.Base64, oldPath: "foo/foo1.js" },
+              { path: "bar/bar2.js", content: toBase64("foo2"), mode: 420, encoding: FileSyncEncoding.Base64, oldPath: "foo/foo2.js" },
+            ]),
+            deleted: [],
+          },
+        });
+      });
+
       it("publishes deleted events on unlink events", async () => {
-        emit.all("unlink", path.join(dir, "file.js"), stats);
-        emit.all("unlink", path.join(dir, "some/deeply/nested/file.js"), stats);
+        emit.all("unlink", path.join(dir, "file.js"));
+        emit.all("unlink", path.join(dir, "some/deeply/nested/file.js"));
 
         await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
         client._subscription(PUBLISH_FILE_SYNC_EVENTS_MUTATION).sink.next({ data: { publishFileSyncEvents: { remoteFilesVersion: "1" } } });
@@ -841,11 +877,11 @@ describe("Sync", () => {
           "baz.js": "baz",
         });
 
-        emit.all("add", path.join(dir, "foo.js"), stats);
+        emit.all("add", path.join(dir, "foo.js"));
         await sleep();
-        emit.all("add", path.join(dir, "bar.js"), stats);
+        emit.all("add", path.join(dir, "bar.js"));
         await sleep();
-        emit.all("add", path.join(dir, "baz.js"), stats);
+        emit.all("add", path.join(dir, "baz.js"));
 
         await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
         client._subscription(PUBLISH_FILE_SYNC_EVENTS_MUTATION).sink.next({ data: { publishFileSyncEvents: { remoteFilesVersion: "1" } } });
@@ -864,7 +900,7 @@ describe("Sync", () => {
       });
 
       it("publishes add events on addDir events", async () => {
-        emit.all("addDir", path.join(dir, "some/deeply/nested/"), stats);
+        emit.all("addDir", path.join(dir, "some/deeply/nested/"));
 
         await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
         client._subscription(PUBLISH_FILE_SYNC_EVENTS_MUTATION).sink.next({ data: { publishFileSyncEvents: { remoteFilesVersion: "1" } } });
@@ -879,7 +915,7 @@ describe("Sync", () => {
       });
 
       it("publishes delete events on unlinkDir events", async () => {
-        emit.all("unlinkDir", path.join(dir, "some/deeply/nested/"), stats);
+        emit.all("unlinkDir", path.join(dir, "some/deeply/nested/"));
 
         await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
         client._subscription(PUBLISH_FILE_SYNC_EVENTS_MUTATION).sink.next({ data: { publishFileSyncEvents: { remoteFilesVersion: "1" } } });
@@ -898,8 +934,8 @@ describe("Sync", () => {
           "another.js": "test",
         });
 
-        emit.all("change", path.join(dir, "delete_me.js"), stats);
-        emit.all("add", path.join(dir, "another.js"), stats);
+        emit.all("change", path.join(dir, "delete_me.js"));
+        emit.all("add", path.join(dir, "another.js"));
 
         await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
         client._subscription(PUBLISH_FILE_SYNC_EVENTS_MUTATION).sink.next({ data: { publishFileSyncEvents: { remoteFilesVersion: "1" } } });
@@ -923,8 +959,8 @@ describe("Sync", () => {
         sync.recentRemoteChanges.add("bar.js");
 
         // emit events affecting the files in recentWrites
-        emit.all("add", path.join(dir, "foo.js"), stats);
-        emit.all("unlink", path.join(dir, "bar.js"), stats);
+        emit.all("add", path.join(dir, "foo.js"));
+        emit.all("unlink", path.join(dir, "bar.js"));
 
         // expect no events to have been published
         expect(sync.publish).not.toHaveBeenCalled();
@@ -942,7 +978,7 @@ describe("Sync", () => {
         });
 
         // emit the first batch of events
-        emit.all("add", path.join(dir, "foo.js"), stats);
+        emit.all("add", path.join(dir, "foo.js"));
 
         // wait for the first batch to be queued
         await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
@@ -959,8 +995,8 @@ describe("Sync", () => {
         });
 
         // emit another batch of events while the first batch is still in progress
-        emit.all("add", path.join(dir, "bar.js"), stats);
-        emit.all("add", path.join(dir, "baz.js"), stats);
+        emit.all("add", path.join(dir, "bar.js"));
+        emit.all("add", path.join(dir, "baz.js"));
 
         // wait for the second batch to be queued
         await sleepUntil(() => sync.queue.size == 1);
@@ -1005,27 +1041,19 @@ describe("Sync", () => {
         await sleepUntil(() => sync.state.filesVersion == 2n);
       });
 
-      it("does not publish events caused by symlinked files", () => {
-        vi.spyOn(sync, "publish");
-
-        emit.all("change", path.join(dir, "symlink.js"), { ...stats, isSymbolicLink: () => true });
-
-        expect(sync.publish).not.toHaveBeenCalled();
-      });
-
       it("does not publish multiple events affecting the same file", async () => {
         await setupDir(dir, {
           "file.js": "foo",
         });
 
         // emit a batch of events that affect the same file
-        emit.all("add", path.join(dir, "file.js"), stats);
-        emit.all("change", path.join(dir, "file.js"), stats);
+        emit.all("add", path.join(dir, "file.js"));
+        emit.all("change", path.join(dir, "file.js"));
         emit.all("unlink", path.join(dir, "file.js"));
 
         // add a small delay and then emit one more event that affects the same file
         await sleep();
-        emit.all("add", path.join(dir, "file.js"), stats);
+        emit.all("add", path.join(dir, "file.js"));
 
         // wait for the publish to be queued
         await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
@@ -1061,10 +1089,10 @@ describe("Sync", () => {
         });
 
         it("does not publish changes from ignored paths", async () => {
-          emit.all("add", path.join(dir, "file.js"), stats);
-          emit.all("unlink", path.join(dir, "some/deeply/file.js"), stats);
-          emit.all("change", path.join(dir, "some/deeply/nested/file.js"), stats);
-          emit.all("change", path.join(dir, "watch/me/file.js"), stats);
+          emit.all("add", path.join(dir, "file.js"));
+          emit.all("unlink", path.join(dir, "some/deeply/file.js"));
+          emit.all("change", path.join(dir, "some/deeply/nested/file.js"));
+          emit.all("change", path.join(dir, "watch/me/file.js"));
 
           await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
 
@@ -1086,9 +1114,9 @@ describe("Sync", () => {
         it("reloads the ignore file when it changes", async () => {
           vi.spyOn(sync, "publish");
 
-          emit.all("add", path.join(dir, "file.js"), stats);
-          emit.all("unlink", path.join(dir, "some/deeply/file.js"), stats);
-          emit.all("change", path.join(dir, "some/deeply/nested/file.js"), stats);
+          emit.all("add", path.join(dir, "file.js"));
+          emit.all("unlink", path.join(dir, "some/deeply/file.js"));
+          emit.all("change", path.join(dir, "some/deeply/nested/file.js"));
 
           expect(sync.publish).not.toHaveBeenCalled();
 
@@ -1100,9 +1128,9 @@ describe("Sync", () => {
             "watch/me/file.js": "bar",
           });
 
-          emit.all("change", path.join(dir, ".ignore"), stats);
-          emit.all("change", path.join(dir, "some/deeply/nested/file.js"), stats);
-          emit.all("change", path.join(dir, "watch/me/file.js"), stats);
+          emit.all("change", path.join(dir, ".ignore"));
+          emit.all("change", path.join(dir, "some/deeply/nested/file.js"));
+          emit.all("change", path.join(dir, "watch/me/file.js"));
 
           await sleepUntil(() => client._subscriptions.has(PUBLISH_FILE_SYNC_EVENTS_MUTATION));
 
@@ -1160,7 +1188,7 @@ describe("Sync", () => {
       });
 
       // send a local change event
-      emit.all("add", path.join(dir, "foo.js"), stats);
+      emit.all("add", path.join(dir, "foo.js"));
 
       const stop = sync.stop();
 
@@ -1197,7 +1225,7 @@ describe("Sync", () => {
 
     it("notifies the user when an error occurs", async () => {
       expect(client._subscriptions.has(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION)).toBe(true);
-      expect(sync.watcher.on).toHaveBeenCalledTimes(2);
+      expect(sync.on).toHaveBeenCalledTimes(2);
 
       client._subscription(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION).sink.error(new ClientError({} as any, "test"));
 
@@ -1218,7 +1246,7 @@ describe("Sync", () => {
 
     it("closes all resources when subscription emits error", async () => {
       expect(client._subscriptions.has(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION)).toBe(true);
-      expect(sync.watcher.on).toHaveBeenCalledTimes(2);
+      expect(sync.on).toHaveBeenCalledTimes(2);
 
       client._subscription(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION).sink.error(new ClientError({} as any, "test"));
 
@@ -1231,7 +1259,7 @@ describe("Sync", () => {
 
     it("closes all resources when subscription emits response with errors", async () => {
       expect(client._subscriptions.has(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION)).toBe(true);
-      expect(sync.watcher.on).toHaveBeenCalledTimes(2);
+      expect(sync.on).toHaveBeenCalledTimes(2);
 
       client._subscription(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION).sink.next({ errors: [new GraphQLError("boom")] });
 
@@ -1244,7 +1272,7 @@ describe("Sync", () => {
 
     it("closes all resources when watcher emits error", async () => {
       expect(client._subscriptions.has(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION)).toBe(true);
-      expect(sync.watcher.on).toHaveBeenCalledTimes(2);
+      expect(sync.on).toHaveBeenCalledTimes(2);
 
       emit.error(new Error(expect.getState().currentTestName));
 

--- a/spec/commands/sync.spec.ts
+++ b/spec/commands/sync.spec.ts
@@ -35,7 +35,7 @@ describe("Sync", () => {
   let dir: string;
   let app: string;
   let sync: Sync;
-  let oldFileStats: (filepath: string) => Stats;
+  let oldFileStats: (filepath: string) => Stats | undefined;
 
   const emit: {
     all: (

--- a/spec/util.ts
+++ b/spec/util.ts
@@ -7,6 +7,7 @@ import type { Payload, Query, Sink } from "../src/utils/client.js";
 import { Client } from "../src/utils/client.js";
 import { walkDir, walkDirSync } from "../src/utils/fs-utils.js";
 import { expect, vi } from "vitest";
+import assert from "assert";
 
 export async function getError(fnThatThrows: () => unknown): Promise<any> {
   try {
@@ -37,12 +38,22 @@ export function expectDirSync(dir: string, expected: Record<string, string>): vo
   expect(actual).toEqual(expected);
 }
 
-export async function setupDir(dir: string, files: Record<string, string>): Promise<void> {
+type FileOrDir =
+  | string
+  | {
+      [filepath: string]: FileOrDir | string;
+    };
+
+export async function setupDir(dir: string, files: Record<string, FileOrDir>): Promise<void> {
   await fs.emptyDir(dir);
   for (const [filepath, content] of Object.entries(files)) {
     if (filepath.endsWith("/")) {
-      await fs.ensureDir(path.join(dir, filepath));
+      if (_.isObject(content)) {
+        await fs.ensureDir(path.join(dir, filepath));
+        await setupDir(path.join(dir, filepath), content);
+      }
     } else {
+      assert(_.isString(content), "file contents must be a string");
       await fs.outputFile(path.join(dir, filepath), content);
     }
   }

--- a/src/__generated__/edit.graphql
+++ b/src/__generated__/edit.graphql
@@ -12,6 +12,11 @@ schema {
   subscription: Subscription
 }
 
+type APIUpgradeConvergePlanResult {
+  items: [JSON!]!
+  success: Boolean!
+}
+
 type ChangeAppDomainResult {
   onlyValidate: Boolean
   reason: String
@@ -36,6 +41,12 @@ scalar DateTime
 
 type DeleteAppStatusResult {
   isNotCreator: Boolean
+  isNotOwner: Boolean
+  success: Boolean!
+}
+
+type EnableFrontendResult {
+  reason: String
   success: Boolean!
 }
 
@@ -67,6 +78,7 @@ input FileSyncChangedEventInput {
   content: String!
   encoding: FileSyncEncoding
   mode: Float!
+  oldPath: String
   path: String!
 }
 
@@ -90,6 +102,11 @@ type GadgetRole {
   selectable: Boolean!
 }
 
+type IdentifySupportConversationResult {
+  identificationEmail: String!
+  identificationToken: String!
+}
+
 scalar JSON
 
 type LogSearchResult {
@@ -104,6 +121,7 @@ type MigrateEnvironmentsResult {
 type Mutation {
   changeAppDomain(newSubdomain: String!, onlyValidate: Boolean): ChangeAppDomainResult
   deleteApp: DeleteAppStatusResult
+  enableFrontend(hasShopifyConnection: Boolean!): EnableFrontendResult
   migrateEnvironments(existingToProduction: Boolean!): MigrateEnvironmentsResult
   patchEnvironmentTree(clientID: EnvironmentTreeClientId!, patches: [JSON!]!): EnvironmentPatchResult
   publish: EnvironmentPublishResult
@@ -111,8 +129,9 @@ type Mutation {
   refreshScopes(appConfigKey: String!, connectionKey: String!, shopId: String!): RefreshScopesResult
   registerWebhooks(connectionKey: String!, keepExtraTopics: Boolean, modelKeys: [String!], shopIds: [String!]!): RegisterWebhooksResult
   removeContributor(email: String!, isInvitation: Boolean!): RemoveContributorResult
-  sendAppInvitation(email: String!, resend: Boolean): SendAppInvitationResult
-  unregisterWebhooks(connectionKey: String!, modelKeys: [String!], shopIds: [String!]): UnregisterWebhooksResult
+  sendAppInvitation(email: String, emails: [String!], resend: Boolean): SendAppInvitationResult
+  unregisterWebhooks(apiKeys: [String!], connectionKey: String!, modelKeys: [String!]): UnregisterWebhooksResult
+  uploadFiles(files: [UploadFile!]!): UploadFilesResult!
 }
 
 input PublishFileSyncEventsInput {
@@ -126,14 +145,18 @@ type PublishFileSyncEventsResult {
 }
 
 type Query {
+  apiUpgradeConvergePlan(currentVersion: String!, targetVersion: String!): APIUpgradeConvergePlanResult
   currentUser: User!
-  environmentTreePath(path: String!): JSON
+  environmentTreeChildKeys(path: String!): [String!]!
+  environmentTreePath(hydrateChildrenGlobs: [String!], path: String!): JSON
+  identifySupportConversation: IdentifySupportConversationResult
   listContributors: [ContributorResult!]!
   logsSearch(direction: String, end: DateTime, limit: Int, query: String!, start: DateTime, step: Int): LogSearchResult!
   remoteFilesVersion: String!
   roles: [GadgetRole!]!
   runTestSupportFunction: JSON
-  typesManifest: TypesManifest!
+  team: TeamResult!
+  typesManifest(dependenciesHash: String!): TypesManifest!
 }
 
 type RefreshScopesResult {
@@ -168,18 +191,42 @@ type Subscription {
   typesManifestStream: TypesManifest!
 }
 
+type TeamMember {
+  contributesToApp: Boolean!
+  email: String!
+}
+
+type TeamResult {
+  availableSeats: Int
+  costPerSeat: String
+  teamMembers: [TeamMember!]!
+}
+
 type TypeManifestEntry {
   declaration: String!
   path: String!
 }
 
 type TypesManifest {
+  cdn: [String!]!
   dependenciesHash: String!
   entries: [TypeManifestEntry!]!
   environmentVersion: Int!
 }
 
 type UnregisterWebhooksResult {
+  success: Boolean!
+}
+
+"""The `Upload` scalar type represents a file upload."""
+scalar Upload
+
+input UploadFile {
+  file: Upload!
+  path: String!
+}
+
+type UploadFilesResult {
   success: Boolean!
 }
 

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -11,82 +11,100 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
+  ID: { input: string | number; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
   /** A date string, such as 2007-12-03, compliant with the `full-date` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
-  Date: any;
+  Date: { input: any; output: any; }
   /** A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
-  DateTime: any;
-  JSON: { [key: string]: any };
+  DateTime: { input: any; output: any; }
+  JSON: { input: { [key: string]: any }; output: { [key: string]: any }; }
+  /** The `Upload` scalar type represents a file upload. */
+  Upload: { input: any; output: any; }
+};
+
+export type ApiUpgradeConvergePlanResult = {
+  __typename?: 'APIUpgradeConvergePlanResult';
+  items: Array<Scalars['JSON']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type ChangeAppDomainResult = {
   __typename?: 'ChangeAppDomainResult';
-  onlyValidate?: Maybe<Scalars['Boolean']>;
-  reason?: Maybe<Scalars['String']>;
-  success: Scalars['Boolean'];
+  onlyValidate?: Maybe<Scalars['Boolean']['output']>;
+  reason?: Maybe<Scalars['String']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type ContributorResult = {
   __typename?: 'ContributorResult';
-  email: Scalars['String'];
-  isOwner: Scalars['Boolean'];
-  isPending: Scalars['Boolean'];
+  email: Scalars['String']['output'];
+  isOwner: Scalars['Boolean']['output'];
+  isPending: Scalars['Boolean']['output'];
 };
 
 export type DeleteAppStatusResult = {
   __typename?: 'DeleteAppStatusResult';
-  isNotCreator?: Maybe<Scalars['Boolean']>;
-  success: Scalars['Boolean'];
+  isNotCreator?: Maybe<Scalars['Boolean']['output']>;
+  isNotOwner?: Maybe<Scalars['Boolean']['output']>;
+  success: Scalars['Boolean']['output'];
+};
+
+export type EnableFrontendResult = {
+  __typename?: 'EnableFrontendResult';
+  reason?: Maybe<Scalars['String']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type EnvironmentPatchResult = {
   __typename?: 'EnvironmentPatchResult';
-  success: Scalars['Boolean'];
+  success: Scalars['Boolean']['output'];
 };
 
 export type EnvironmentPublishResult = {
   __typename?: 'EnvironmentPublishResult';
-  success: Scalars['Boolean'];
+  success: Scalars['Boolean']['output'];
 };
 
 export type EnvironmentSubscriptionResult = {
   __typename?: 'EnvironmentSubscriptionResult';
-  patches: Array<Scalars['JSON']>;
+  patches: Array<Scalars['JSON']['output']>;
 };
 
 export type EnvironmentTreeClientId = {
-  clientType: Scalars['String'];
-  id: Scalars['String'];
+  clientType: Scalars['String']['input'];
+  id: Scalars['String']['input'];
 };
 
 export type FileSyncChangedEvent = {
   __typename?: 'FileSyncChangedEvent';
-  content: Scalars['String'];
+  content: Scalars['String']['output'];
   encoding: FileSyncEncoding;
-  mode: Scalars['Float'];
-  path: Scalars['String'];
+  mode: Scalars['Float']['output'];
+  path: Scalars['String']['output'];
 };
 
 export type FileSyncChangedEventInput = {
-  content: Scalars['String'];
+  content: Scalars['String']['input'];
   encoding?: InputMaybe<FileSyncEncoding>;
-  mode: Scalars['Float'];
-  path: Scalars['String'];
+  mode: Scalars['Float']['input'];
+  oldPath?: InputMaybe<Scalars['String']['input']>;
+  path: Scalars['String']['input'];
 };
 
 export type FileSyncDeletedEvent = {
   __typename?: 'FileSyncDeletedEvent';
-  path: Scalars['String'];
+  path: Scalars['String']['output'];
 };
 
 export type FileSyncDeletedEventInput = {
-  path: Scalars['String'];
+  path: Scalars['String']['input'];
 };
 
 export enum FileSyncEncoding {
@@ -96,27 +114,34 @@ export enum FileSyncEncoding {
 
 export type GadgetRole = {
   __typename?: 'GadgetRole';
-  key: Scalars['String'];
-  name: Scalars['String'];
-  order: Scalars['Int'];
-  selectable: Scalars['Boolean'];
+  key: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  order: Scalars['Int']['output'];
+  selectable: Scalars['Boolean']['output'];
+};
+
+export type IdentifySupportConversationResult = {
+  __typename?: 'IdentifySupportConversationResult';
+  identificationEmail: Scalars['String']['output'];
+  identificationToken: Scalars['String']['output'];
 };
 
 export type LogSearchResult = {
   __typename?: 'LogSearchResult';
-  data: Scalars['JSON'];
-  status: Scalars['String'];
+  data: Scalars['JSON']['output'];
+  status: Scalars['String']['output'];
 };
 
 export type MigrateEnvironmentsResult = {
   __typename?: 'MigrateEnvironmentsResult';
-  success: Scalars['Boolean'];
+  success: Scalars['Boolean']['output'];
 };
 
 export type Mutation = {
   __typename?: 'Mutation';
   changeAppDomain?: Maybe<ChangeAppDomainResult>;
   deleteApp?: Maybe<DeleteAppStatusResult>;
+  enableFrontend?: Maybe<EnableFrontendResult>;
   migrateEnvironments?: Maybe<MigrateEnvironmentsResult>;
   patchEnvironmentTree?: Maybe<EnvironmentPatchResult>;
   publish?: Maybe<EnvironmentPublishResult>;
@@ -126,23 +151,29 @@ export type Mutation = {
   removeContributor?: Maybe<RemoveContributorResult>;
   sendAppInvitation?: Maybe<SendAppInvitationResult>;
   unregisterWebhooks?: Maybe<UnregisterWebhooksResult>;
+  uploadFiles: UploadFilesResult;
 };
 
 
 export type MutationChangeAppDomainArgs = {
-  newSubdomain: Scalars['String'];
-  onlyValidate?: InputMaybe<Scalars['Boolean']>;
+  newSubdomain: Scalars['String']['input'];
+  onlyValidate?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type MutationEnableFrontendArgs = {
+  hasShopifyConnection: Scalars['Boolean']['input'];
 };
 
 
 export type MutationMigrateEnvironmentsArgs = {
-  existingToProduction: Scalars['Boolean'];
+  existingToProduction: Scalars['Boolean']['input'];
 };
 
 
 export type MutationPatchEnvironmentTreeArgs = {
   clientID: EnvironmentTreeClientId;
-  patches: Array<Scalars['JSON']>;
+  patches: Array<Scalars['JSON']['input']>;
 };
 
 
@@ -152,108 +183,135 @@ export type MutationPublishFileSyncEventsArgs = {
 
 
 export type MutationRefreshScopesArgs = {
-  appConfigKey: Scalars['String'];
-  connectionKey: Scalars['String'];
-  shopId: Scalars['String'];
+  appConfigKey: Scalars['String']['input'];
+  connectionKey: Scalars['String']['input'];
+  shopId: Scalars['String']['input'];
 };
 
 
 export type MutationRegisterWebhooksArgs = {
-  connectionKey: Scalars['String'];
-  keepExtraTopics?: InputMaybe<Scalars['Boolean']>;
-  modelKeys?: InputMaybe<Array<Scalars['String']>>;
-  shopIds: Array<Scalars['String']>;
+  connectionKey: Scalars['String']['input'];
+  keepExtraTopics?: InputMaybe<Scalars['Boolean']['input']>;
+  modelKeys?: InputMaybe<Array<Scalars['String']['input']>>;
+  shopIds: Array<Scalars['String']['input']>;
 };
 
 
 export type MutationRemoveContributorArgs = {
-  email: Scalars['String'];
-  isInvitation: Scalars['Boolean'];
+  email: Scalars['String']['input'];
+  isInvitation: Scalars['Boolean']['input'];
 };
 
 
 export type MutationSendAppInvitationArgs = {
-  email: Scalars['String'];
-  resend?: InputMaybe<Scalars['Boolean']>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  emails?: InputMaybe<Array<Scalars['String']['input']>>;
+  resend?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 
 export type MutationUnregisterWebhooksArgs = {
-  connectionKey: Scalars['String'];
-  modelKeys?: InputMaybe<Array<Scalars['String']>>;
-  shopIds?: InputMaybe<Array<Scalars['String']>>;
+  apiKeys?: InputMaybe<Array<Scalars['String']['input']>>;
+  connectionKey: Scalars['String']['input'];
+  modelKeys?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+
+export type MutationUploadFilesArgs = {
+  files: Array<UploadFile>;
 };
 
 export type PublishFileSyncEventsInput = {
   changed: Array<FileSyncChangedEventInput>;
   deleted: Array<FileSyncDeletedEventInput>;
-  expectedRemoteFilesVersion: Scalars['String'];
+  expectedRemoteFilesVersion: Scalars['String']['input'];
 };
 
 export type PublishFileSyncEventsResult = {
   __typename?: 'PublishFileSyncEventsResult';
-  remoteFilesVersion: Scalars['String'];
+  remoteFilesVersion: Scalars['String']['output'];
 };
 
 export type Query = {
   __typename?: 'Query';
+  apiUpgradeConvergePlan?: Maybe<ApiUpgradeConvergePlanResult>;
   currentUser: User;
-  environmentTreePath?: Maybe<Scalars['JSON']>;
+  environmentTreeChildKeys: Array<Scalars['String']['output']>;
+  environmentTreePath?: Maybe<Scalars['JSON']['output']>;
+  identifySupportConversation?: Maybe<IdentifySupportConversationResult>;
   listContributors: Array<ContributorResult>;
   logsSearch: LogSearchResult;
-  remoteFilesVersion: Scalars['String'];
+  remoteFilesVersion: Scalars['String']['output'];
   roles: Array<GadgetRole>;
-  runTestSupportFunction?: Maybe<Scalars['JSON']>;
+  runTestSupportFunction?: Maybe<Scalars['JSON']['output']>;
+  team: TeamResult;
   typesManifest: TypesManifest;
 };
 
 
+export type QueryApiUpgradeConvergePlanArgs = {
+  currentVersion: Scalars['String']['input'];
+  targetVersion: Scalars['String']['input'];
+};
+
+
+export type QueryEnvironmentTreeChildKeysArgs = {
+  path: Scalars['String']['input'];
+};
+
+
 export type QueryEnvironmentTreePathArgs = {
-  path: Scalars['String'];
+  hydrateChildrenGlobs?: InputMaybe<Array<Scalars['String']['input']>>;
+  path: Scalars['String']['input'];
 };
 
 
 export type QueryLogsSearchArgs = {
-  direction?: InputMaybe<Scalars['String']>;
-  end?: InputMaybe<Scalars['DateTime']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  query: Scalars['String'];
-  start?: InputMaybe<Scalars['DateTime']>;
-  step?: InputMaybe<Scalars['Int']>;
+  direction?: InputMaybe<Scalars['String']['input']>;
+  end?: InputMaybe<Scalars['DateTime']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  query: Scalars['String']['input'];
+  start?: InputMaybe<Scalars['DateTime']['input']>;
+  step?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryTypesManifestArgs = {
+  dependenciesHash: Scalars['String']['input'];
 };
 
 export type RefreshScopesResult = {
   __typename?: 'RefreshScopesResult';
-  success: Scalars['Boolean'];
+  success: Scalars['Boolean']['output'];
 };
 
 export type RegisterWebhooksResult = {
   __typename?: 'RegisterWebhooksResult';
-  success: Scalars['Boolean'];
+  success: Scalars['Boolean']['output'];
 };
 
 export type RemoteFileSyncEvents = {
   __typename?: 'RemoteFileSyncEvents';
   changed: Array<FileSyncChangedEvent>;
   deleted: Array<FileSyncDeletedEvent>;
-  remoteFilesVersion: Scalars['String'];
+  remoteFilesVersion: Scalars['String']['output'];
 };
 
 export type RemoveContributorResult = {
   __typename?: 'RemoveContributorResult';
-  reason?: Maybe<Scalars['String']>;
-  success: Scalars['Boolean'];
+  reason?: Maybe<Scalars['String']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type SendAppInvitationResult = {
   __typename?: 'SendAppInvitationResult';
-  reason?: Maybe<Scalars['String']>;
-  success: Scalars['Boolean'];
+  reason?: Maybe<Scalars['String']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type Subscription = {
   __typename?: 'Subscription';
-  editorActive?: Maybe<Scalars['Boolean']>;
+  editorActive?: Maybe<Scalars['Boolean']['output']>;
   environmentTreePathPatches?: Maybe<EnvironmentSubscriptionResult>;
   logsSearch: LogSearchResult;
   remoteFileSyncEvents: RemoteFileSyncEvents;
@@ -263,48 +321,72 @@ export type Subscription = {
 
 export type SubscriptionEnvironmentTreePathPatchesArgs = {
   clientID: EnvironmentTreeClientId;
-  path: Scalars['String'];
+  path: Scalars['String']['input'];
 };
 
 
 export type SubscriptionLogsSearchArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  query: Scalars['String'];
-  start?: InputMaybe<Scalars['DateTime']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  query: Scalars['String']['input'];
+  start?: InputMaybe<Scalars['DateTime']['input']>;
 };
 
 
 export type SubscriptionRemoteFileSyncEventsArgs = {
   encoding?: InputMaybe<FileSyncEncoding>;
-  localFilesVersion: Scalars['String'];
+  localFilesVersion: Scalars['String']['input'];
+};
+
+export type TeamMember = {
+  __typename?: 'TeamMember';
+  contributesToApp: Scalars['Boolean']['output'];
+  email: Scalars['String']['output'];
+};
+
+export type TeamResult = {
+  __typename?: 'TeamResult';
+  availableSeats?: Maybe<Scalars['Int']['output']>;
+  costPerSeat?: Maybe<Scalars['String']['output']>;
+  teamMembers: Array<TeamMember>;
 };
 
 export type TypeManifestEntry = {
   __typename?: 'TypeManifestEntry';
-  declaration: Scalars['String'];
-  path: Scalars['String'];
+  declaration: Scalars['String']['output'];
+  path: Scalars['String']['output'];
 };
 
 export type TypesManifest = {
   __typename?: 'TypesManifest';
-  dependenciesHash: Scalars['String'];
+  cdn: Array<Scalars['String']['output']>;
+  dependenciesHash: Scalars['String']['output'];
   entries: Array<TypeManifestEntry>;
-  environmentVersion: Scalars['Int'];
+  environmentVersion: Scalars['Int']['output'];
 };
 
 export type UnregisterWebhooksResult = {
   __typename?: 'UnregisterWebhooksResult';
-  success: Scalars['Boolean'];
+  success: Scalars['Boolean']['output'];
+};
+
+export type UploadFile = {
+  file: Scalars['Upload']['input'];
+  path: Scalars['String']['input'];
+};
+
+export type UploadFilesResult = {
+  __typename?: 'UploadFilesResult';
+  success: Scalars['Boolean']['output'];
 };
 
 export type User = {
   __typename?: 'User';
-  email: Scalars['String'];
-  name?: Maybe<Scalars['String']>;
+  email: Scalars['String']['output'];
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 export type RemoteFileSyncEventsSubscriptionVariables = Exact<{
-  localFilesVersion: Scalars['String'];
+  localFilesVersion: Scalars['String']['input'];
 }>;
 
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -428,7 +428,7 @@ export default class Sync extends BaseCommand<typeof Sync> {
     let error: unknown;
     const stopped = new PromiseSignal();
 
-    this.watcher = new FSWatcher(`${this.dir}`, {
+    this.watcher = new FSWatcher(this.dir, {
       ignore: (filepath: string) => {
         return this.ignorer.ignores(filepath);
       },

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,7 +1,7 @@
 import { Args, Flags } from "@oclif/core";
 import assert from "assert";
 import chalkTemplate from "chalk-template";
-import { FSWatcher } from "chokidar";
+import { default as FSWatcher } from "watcher";
 import { format } from "date-fns";
 import { execa } from "execa";
 import type { Stats } from "fs-extra";
@@ -190,6 +190,10 @@ export default class Sync extends BaseCommand<typeof Sync> {
    */
   stop!: (error?: unknown) => Promise<void>;
 
+  static fileStats(path: string) {
+    return fs.statSync(path);
+  }
+
   /**
    * Turns an absolute filepath into a relative one from {@linkcode dir}.
    */
@@ -320,16 +324,6 @@ export default class Sync extends BaseCommand<typeof Sync> {
     // local files/folders that should never be published
     this.ignorer = new FSIgnorer(this.dir, ["node_modules", ".gadget", ".git"]);
 
-    this.watcher = new FSWatcher({
-      ignored: (filepath) => this.ignorer.ignores(filepath),
-      // don't emit an event for every watched file on boot
-      ignoreInitial: true,
-      // make sure stats are always present on add/change events
-      alwaysStat: true,
-      // wait for the entire file to be written before emitting add/change events
-      awaitWriteFinish: { pollInterval: this.flags["file-poll-interval"], stabilityThreshold: this.flags["file-stability-threshold"] },
-    });
-
     this.debug("starting");
 
     if (!which.sync("yarn", { nothrow: true })) {
@@ -428,6 +422,16 @@ export default class Sync extends BaseCommand<typeof Sync> {
   async run(): Promise<void> {
     let error: unknown;
     const stopped = new PromiseSignal();
+
+    this.watcher = new FSWatcher(`${this.dir}`, {
+      ignore: (filepath: string) => {
+        return this.ignorer.ignores(filepath);
+      },
+      // don't emit an event for every watched file on boot
+      ignoreInitial: true,
+      renameDetection: true,
+      recursive: true,
+    });
 
     this.stop = async (e?: unknown) => {
       if (this.status != SyncStatus.RUNNING) return;
@@ -551,7 +555,12 @@ export default class Sync extends BaseCommand<typeof Sync> {
       }
     );
 
-    const localFilesBuffer = new Map<string, { mode: number; isDirectory: boolean } | { isDeleted: true; isDirectory: boolean }>();
+    const localFilesBuffer = new Map<
+      string,
+      | { mode: number; isDirectory: boolean }
+      | { isDeleted: true; isDirectory: boolean }
+      | { mode: number; oldPath: string; newPath: string; isDirectory: boolean }
+    >();
 
     this.publish = _.debounce(() => {
       const localFiles = new Map(localFilesBuffer.entries());
@@ -567,12 +576,15 @@ export default class Sync extends BaseCommand<typeof Sync> {
             return;
           }
 
+          const isRename = "oldPath" in file;
+
           try {
             changed.push({
               path: normalizedPath,
               mode: file.mode,
               content: file.isDirectory ? "" : await fs.readFile(this.absolute(normalizedPath), "base64"),
               encoding: FileSyncEncoding.Base64,
+              ...(isRename ? { oldPath: file.oldPath } : undefined),
             });
           } catch (error) {
             // A file could have been changed and then deleted before we process the change event, so the readFile
@@ -607,56 +619,66 @@ export default class Sync extends BaseCommand<typeof Sync> {
       });
     }, this.flags["file-push-delay"]);
 
-    this.watcher
-      .add(`${this.dir}/**/*`)
-      .on("error", (error) => void this.stop(error))
-      .on("all", (event, absolutePath, stats) => {
-        const normalizedPath = this.normalize(absolutePath, event == "addDir" || event == "unlinkDir");
+    this.on("error", (error) => void this.stop(error)).on("all", (event: string, absolutePath: string, renamedPath: string) => {
+      const filePath = event === "rename" || event === "renameDir" ? renamedPath : absolutePath;
+      const isDirectory = event === "renameDir" || event === "addDir" || event === "unlinkDir";
+      const normalizedPath = this.normalize(filePath, isDirectory);
+      const stats = Sync.fileStats(filePath);
 
-        if (stats?.isSymbolicLink?.()) {
-          this.debug("skipping event caused by symlink %s", normalizedPath);
-          return;
-        }
+      // this shouldn't ever be the case using watcher since it doesn't support symlinks but we'll keep it here just in case we ever switch to another lib that does support it
+      if (stats?.isSymbolicLink?.()) {
+        this.debug("skipping event caused by symlink %s", normalizedPath);
+        return;
+      }
 
-        if (absolutePath == this.ignorer.filepath) {
-          this.ignorer.reload();
-        } else if (this.ignorer.ignores(absolutePath)) {
-          this.debug("skipping event caused by ignored file %s", normalizedPath);
-          return;
-        }
+      if (filePath == this.ignorer.filepath) {
+        this.ignorer.reload();
+      } else if (this.ignorer.ignores(filePath)) {
+        this.debug("skipping event caused by ignored file %s", normalizedPath);
+        return;
+      }
 
-        // we only update the mtime if the file is not ignored, because if we restart and the mtime is set to an ignored
-        // file, then it could be greater than the mtime of all non ignored files and we'll think that local files have
-        // changed when only an ignored one has
-        if (stats && stats.mtime.getTime() > this.state.mtime) {
-          this.state.mtime = stats.mtime.getTime();
-        }
+      // we only update the mtime if the file is not ignored, because if we restart and the mtime is set to an ignored
+      // file, then it could be greater than the mtime of all non ignored files and we'll think that local files have
+      // changed when only an ignored one has
+      if (stats && stats.mtime.getTime() > this.state.mtime) {
+        this.state.mtime = stats.mtime.getTime();
+      }
 
-        if (this.recentRemoteChanges.delete(normalizedPath)) {
-          this.debug("skipping event caused by recent write %s", normalizedPath);
-          return;
-        }
+      if (this.recentRemoteChanges.delete(normalizedPath)) {
+        this.debug("skipping event caused by recent write %s", normalizedPath);
+        return;
+      }
 
-        this.debug("file changed %s", normalizedPath, event);
+      this.debug("file changed %s", normalizedPath, event);
 
-        switch (event) {
-          case "add":
-          case "change":
-            assert(stats, "missing stats on add/change event");
-            localFilesBuffer.set(normalizedPath, { mode: stats.mode, isDirectory: false });
-            break;
-          case "addDir":
-            assert(stats, "missing stats on addDir event");
-            localFilesBuffer.set(normalizedPath, { mode: stats.mode, isDirectory: true });
-            break;
-          case "unlinkDir":
-          case "unlink":
-            localFilesBuffer.set(normalizedPath, { isDeleted: true, isDirectory: event === "unlinkDir" });
-            break;
-        }
+      switch (event) {
+        case "add":
+        case "change":
+          assert(stats, "missing stats on add/change event");
+          localFilesBuffer.set(normalizedPath, { mode: stats.mode, isDirectory: false });
+          break;
+        case "addDir":
+          assert(stats, "missing stats on addDir event");
+          localFilesBuffer.set(normalizedPath, { mode: stats.mode, isDirectory: true });
+          break;
+        case "unlinkDir":
+        case "unlink":
+          localFilesBuffer.set(normalizedPath, { isDeleted: true, isDirectory: event === "unlinkDir" });
+          break;
+        case "rename":
+        case "renameDir":
+          localFilesBuffer.set(normalizedPath, {
+            oldPath: this.normalize(absolutePath, isDirectory),
+            newPath: normalizedPath,
+            isDirectory: event === "renameDir",
+            mode: stats.mode,
+          });
+          break;
+      }
 
-        this.publish();
-      });
+      this.publish();
+    });
 
     this.status = SyncStatus.RUNNING;
 
@@ -695,6 +717,11 @@ export default class Sync extends BaseCommand<typeof Sync> {
     } else {
       this.log("Goodbye!");
     }
+  }
+
+  on(eventName: string | symbol, listener: (...args: any[]) => void): this {
+    this.watcher.on(eventName, listener);
+    return this;
   }
 
   /**

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -190,8 +190,13 @@ export default class Sync extends BaseCommand<typeof Sync> {
    */
   stop!: (error?: unknown) => Promise<void>;
 
-  static fileStats(path: string) {
-    return fs.statSync(path);
+  static fileStats(path: string): Stats | undefined {
+    try {
+      return fs.statSync(path);
+    } catch (error) {
+      ignoreEnoent(error);
+      return undefined;
+    }
   }
 
   /**
@@ -668,6 +673,7 @@ export default class Sync extends BaseCommand<typeof Sync> {
           break;
         case "rename":
         case "renameDir":
+          assert(stats, "missing stats on rename/renameDir event");
           localFilesBuffer.set(normalizedPath, {
             oldPath: this.normalize(absolutePath, isDirectory),
             newPath: normalizedPath,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -90,22 +90,6 @@ export default class Sync extends BaseCommand<typeof Sync> {
       default: 100,
       hidden: true,
     }),
-    "file-stability-threshold": Flags.integer({
-      name: "file-stability-threshold",
-      summary: "Time in milliseconds a file's size must remain the same.",
-      helpGroup: "file",
-      helpValue: "ms",
-      default: 500,
-      hidden: true,
-    }),
-    "file-poll-interval": Flags.integer({
-      name: "file-poll-interval",
-      description: "Interval in milliseconds between polling a file's size.",
-      helpGroup: "file",
-      helpValue: "ms",
-      default: 100,
-      hidden: true,
-    }),
   };
 
   static override examples = [

--- a/src/utils/fs-utils.ts
+++ b/src/utils/fs-utils.ts
@@ -19,6 +19,10 @@ export class FSIgnorer {
   ignores(filepath: string): boolean {
     const relative = path.isAbsolute(filepath) ? path.relative(this._rootDir, filepath) : filepath;
     if (relative == "") return false;
+    // anything above the root dir is ignored
+    if (relative == "..") {
+      return true;
+    }
     return this._ignorer.ignores(relative);
   }
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -9,5 +9,6 @@ export default defineConfig({
     chaiConfig: {
       truncateThreshold: 10_000,
     },
+    exclude: [".direnv/**/*.spec.ts"],
   },
 });


### PR DESCRIPTION
DO NOT MERGE UNTIL https://github.com/gadget-inc/gadget/pull/6955 has been released

This PR switches the fs watcher from `chokidar` to `watcher` which supports rename events. Some necessary changes:
- `watcher` doesn't support symlinks but we're skipping over those anyways
- `watcher` doesn't provider `stats` with events so we need to get those ourselves
- `watcher` doesn't have the same `awaitWriteFinish` option as `chokidar`. Not sure if we ran into any situations or issues where that was required.
- `watcher` doesn't support globs but I don't think that was really necessary as watching the entire dir works just fine

In conjunction with https://github.com/gadget-inc/gadget/pull/6955 will allow us to propagate renamed files to source file references elsewhere in Gadget