### PR TITLE
Make fileStats handle deleted files/folders

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14447,15 +14447,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/glob/node_modules/minipass": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
@@ -31765,13 +31756,6 @@
             "minimatch": "^9.0.0",
             "minipass": "^5.0.0 || ^6.0.0",
             "path-scurry": "^1.7.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
         "graceful-fs": {

--- a/spec/commands/sync.spec.ts
+++ b/spec/commands/sync.spec.ts
@@ -35,7 +35,7 @@ describe("Sync", () => {
   let dir: string;
   let app: string;
   let sync: Sync;
-  let oldFileStats: (filepath: string) => Stats;
+  let oldFileStats: (filepath: string) => Stats | undefined;
 
   const emit: {
     all: (

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -190,8 +190,13 @@ export default class Sync extends BaseCommand<typeof Sync> {
    */
   stop!: (error?: unknown) => Promise<void>;
 
-  static fileStats(path: string) {
-    return fs.statSync(path);
+  static fileStats(path: string): Stats | undefined {
+    try {
+      return fs.statSync(path);
+    } catch (error) {
+      ignoreEnoent(error);
+      return undefined;
+    }
   }
 
   /**
@@ -668,6 +673,7 @@ export default class Sync extends BaseCommand<typeof Sync> {
           break;
         case "rename":
         case "renameDir":
+          assert(stats, "missing stats on rename/renameDir event");
           localFilesBuffer.set(normalizedPath, {
             oldPath: this.normalize(absolutePath, isDirectory),
             newPath: normalizedPath,


### PR DESCRIPTION
When we receive an `unlink` or `unlinkDir` event and call `fileStats` on the file, it causes ggt to crash. This makes our `fileStats` function handle deleted files.