### PR TITLE
Use `file-watch-debounce` for sleep duration

### DIFF
--- a/spec/commands/sync.spec.ts
+++ b/spec/commands/sync.spec.ts
@@ -1268,7 +1268,7 @@ describe("Sync", () => {
           fs.outputFileSync(path.join(dir, "file.js"), "foo");
 
           // give the watcher a chance to see the file
-          await sleep(1000);
+          await sleep(sync.flags["file-watch-debounce"] + 100);
 
           // no changes should have been published
           expect(sync.publish).not.toHaveBeenCalled();

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -90,6 +90,38 @@ export default class Sync extends BaseCommand<typeof Sync> {
       default: 100,
       hidden: true,
     }),
+    // The following flags are passed to FSWatcher (https://github.com/fabiospampinato/watcher)
+    "file-watch-debounce": Flags.integer({
+      summary: "Amount of milliseconds to debounce file changed events",
+      helpGroup: "file",
+      helpValue: "ms",
+      default: 300,
+      hidden: true,
+    }),
+    "file-watch-poll-interval": Flags.integer({
+      summary:
+        "Polling is used as a last resort measure when watching non-existent paths inside non-existent directories, this controls how often polling is performed, in milliseconds. You can set it to a lower value to make the app detect events much more quickly, but don't set it too low if you are watching many paths that require polling as polling is expensive.",
+      helpGroup: "file",
+      helpValue: "ms",
+      default: 3_000,
+      hidden: true,
+    }),
+    "file-watch-poll-timeout": Flags.integer({
+      summary:
+        "Sometimes polling will fail, for example if there are too many file descriptors currently open, usually eventually polling will succeed after a few tries though, this controls the amount of milliseconds the library should keep retrying for.",
+      helpGroup: "file",
+      helpValue: "ms",
+      default: 20_000,
+      hidden: true,
+    }),
+    "file-watch-rename-timeout": Flags.integer({
+      summary:
+        "Amount of milliseconds to wait for a potential rename/renameDir event to be detected. The higher this value is the more reliably renames will be detected, but don't set this too high, or the emission of some events could be delayed by that amount. The higher this value is the longer the library will take to emit add/addDir/unlink/unlinkDir events.",
+      helpGroup: "file",
+      helpValue: "ms",
+      default: 1_250,
+      hidden: true,
+    }),
   };
 
   static override examples = [
@@ -601,6 +633,10 @@ export default class Sync extends BaseCommand<typeof Sync> {
       ignoreInitial: true,
       renameDetection: true,
       recursive: true,
+      debounce: this.flags["file-watch-debounce"],
+      pollingInterval: this.flags["file-watch-poll-interval"],
+      pollingTimeout: this.flags["file-watch-poll-timeout"],
+      renameTimeout: this.flags["file-watch-rename-timeout"],
     });
 
     this.watcher.once("error", (error) => void this.stop(error));


### PR DESCRIPTION
This is an attempt to fix the following flake that keeps popping up on `ubuntu-latest`

```
> ggt@0.2.1 test
> cross-env NODE_OPTIONS="--no-warnings --loader ./node_modules/ts-node/esm.mjs" vitest


 RUN  v0.33.0 /home/runner/work/ggt/ggt

 ❯ spec/commands/sync.spec.ts  (52 tests | 1 failed | 1 skipped) 97298ms
   ❯ spec/commands/sync.spec.ts > Sync > run > publishing > with an ignore file > reloads the ignore file when it changes
     → Hook timed out in [6](https://github.com/gadget-inc/ggt/actions/runs/5512326345/jobs/10049019813?pr=614#step:5:7)0000ms.
If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
 ✓ spec/services/base-command.spec.ts  (18 tests) 129ms
 ✓ spec/services/context.spec.ts  (18 tests) 161ms
 ✓ spec/services/errors.spec.ts  (10 tests) 59ms
 ✓ spec/services/flags.spec.ts  (10 tests) 56ms
 ✓ spec/commands/list.spec.ts  (3 tests) 29ms
 ✓ spec/commands/whoami.spec.ts  (3 tests) 31ms
 ✓ spec/commands/logout.spec.ts  (3 tests) 33ms
 ✓ spec/commands/login.spec.ts  (1 test) 10ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  spec/commands/sync.spec.ts > Sync > run > publishing > with an ignore file > reloads the ignore file when it changes
Error: Hook timed out in 60000ms.
If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

 Test Files  1 failed | 8 passed (9)
      Tests  1 failed | 116 passed | 1 todo (118)
   Start at  19:4[7](https://github.com/gadget-inc/ggt/actions/runs/5512326345/jobs/10049019813?pr=614#step:5:8):26
   Duration  101.07s (transform 2[8](https://github.com/gadget-inc/ggt/actions/runs/5512326345/jobs/10049019813?pr=614#step:5:9)4ms, setup 856ms, collect 1.21s, tests [9](https://github.com/gadget-inc/ggt/actions/runs/5512326345/jobs/10049019813?pr=614#step:5:10)7.81s, environment 0ms, prepare 136ms)

Error: Process completed with exit code 1.
```