### PR TITLE
Catch `open` errors

### DIFF
--- a/.changeset/lazy-weeks-try.md
+++ b/.changeset/lazy-weeks-try.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Print login url if open fails

--- a/spec/commands/login.spec.ts
+++ b/spec/commands/login.spec.ts
@@ -22,6 +22,7 @@ describe("login", () => {
       requestListener = cb ?? (opt as http.RequestListener);
       return server;
     });
+    open.mockReset();
   });
 
   it("opens a browser to the login page, waits for the user to login, set's the returned session, and redirects to /auth/cli?success=true", async () => {
@@ -67,6 +68,64 @@ describe("login", () => {
       "We've opened Gadget's login page using your default browser.
 
       Please log in and then return to this terminal.
+
+      Hello, Jane Doe (test@example.com)
+
+      "
+    `);
+    expect(res.writeHead).toHaveBeenCalledWith(303, { Location: `https://${config.domains.services}/auth/cli?success=true` });
+    expect(res.end).toHaveBeenCalled();
+    expect(server.close).toHaveBeenCalled();
+  });
+
+  it("prints the login page when open fails, waits for the user to login, set's the returned session, and redirects to /auth/cli?success=true", async () => {
+    writeSession(undefined);
+    vi.spyOn(user, "getUser").mockResolvedValue(testUser);
+    open.mockRejectedValue(new Error("boom"));
+
+    void run();
+
+    await sleepUntil(() => http.createServer.mock.calls.length > 0);
+    expect(getPort).toHaveBeenCalled();
+    expect(requestListener!).toBeDefined();
+    expect(server.listen).toHaveBeenCalledWith(port);
+    expect(open).toHaveBeenCalledWith(
+      `https://${config.domains.services}/auth/login?returnTo=${encodeURIComponent(
+        `https://${config.domains.services}/auth/cli/callback?port=${port}`,
+      )}`,
+    );
+    expectStdout().toMatchInlineSnapshot(`
+      "Please open the following URL in your browser and log in:
+
+        https://app.ggt.dev/auth/login?returnTo=https%3A%2F%2Fapp.ggt.dev%2Fauth%2Fcli%2Fcallback%3Fport%3D1234
+
+      Once logged in, return to this terminal.
+
+      "
+    `);
+
+    // we should be at `await receiveSession`
+    expect(readSession()).toBeUndefined();
+    expect(user.getUser).not.toHaveBeenCalled();
+
+    const req = new http.IncomingMessage(null as any);
+    req.url = `?session=test`;
+
+    const res = new http.ServerResponse(req);
+    vi.spyOn(res, "writeHead");
+    vi.spyOn(res, "end");
+
+    requestListener!(req, res);
+
+    await sleepUntil(() => server.close.mock.calls.length > 0);
+    expect(readSession()).toBe("test");
+    expect(user.getUser).toHaveBeenCalled();
+    expectStdout().toMatchInlineSnapshot(`
+      "Please open the following URL in your browser and log in:
+
+        https://app.ggt.dev/auth/login?returnTo=https%3A%2F%2Fapp.ggt.dev%2Fauth%2Fcli%2Fcallback%3Fport%3D1234
+
+      Once logged in, return to this terminal.
 
       Hello, Jane Doe (test@example.com)
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -73,13 +73,24 @@ export const run = async () => {
     // send the session to the server we just started.
     const url = new URL(`https://${config.domains.services}/auth/login`);
     url.searchParams.set("returnTo", `https://${config.domains.services}/auth/cli/callback?port=${port}`);
-    await open(url.toString());
 
-    println`
+    try {
+      await open(url.toString());
+      println`
         We've opened Gadget's login page using your default browser.
 
         Please log in and then return to this terminal.\n
     `;
+    } catch (error) {
+      log.error("failed to open browser", { error });
+      println`
+        Please open the following URL in your browser and log in:
+
+          {gray ${url.toString()}}
+
+        Once logged in, return to this terminal.\n
+      `;
+    }
 
     await receiveSession;
   } finally {


### PR DESCRIPTION
A user is running into the following error during the login step. It looks like the `open` package is throwing an error:

```
Error: spawn UNKNOWN
    at baseOpen (file:///C:/Users/hp/AppData/Local/npm-cache/_npx/9a4e7709ce82f24b/node_modules/ggt/node_modules/open/index.js:250:34)
    at async run (file:///C:/Users/hp/AppData/Local/npm-cache/_npx/9a4e7709ce82f24b/node_modules/ggt/lib/commands/login.js:69:9)
    at async getUserOrLogin (file:///C:/Users/hp/AppData/Local/npm-cache/_npx/9a4e7709ce82f24b/node_modules/ggt/lib/services/user.js:64:5)
    at async Sync.init (file:///C:/Users/hp/AppData/Local/npm-cache/_npx/9a4e7709ce82f24b/node_modules/ggt/lib/commands/sync.js:150:22)
    at async run (file:///C:/Users/hp/AppData/Local/npm-cache/_npx/9a4e7709ce82f24b/node_modules/ggt/lib/commands/root.js:75:9)
    at async file:///C:/Users/hp/AppData/Local/npm-cache/_npx/9a4e7709ce82f24b/node_modules/ggt/lib/main.js:10:1
```

I wasn't able to reproduce this on a windows computer, so rather than trying to fix this bug blind, I'm just printing the login url so users can open it manually.