### PR TITLE
Use PQueue inside EditGraphQL subscriptions

### DIFF
--- a/spec/__support__/edit-graphql.ts
+++ b/spec/__support__/edit-graphql.ts
@@ -153,17 +153,17 @@ export type MockEditGraphQLSubscription<Query extends GraphQLQuery = GraphQLQuer
   /**
    * Emits a result to the subscription.
    */
-  emitResult(value: Query["Result"]): void;
+  emitResult(value: Query["Result"]): Promisable<void>;
 
   /**
    * Emits an error to the subscription.
    */
-  emitError(error: EditGraphQLError): void;
+  emitError(error: EditGraphQLError): Promisable<void>;
 
   /**
    * Emits the onComplete event to the subscription.
    */
-  emitComplete(): void;
+  emitComplete(): Promisable<void>;
 };
 
 export const makeMockEditGraphQLSubscriptions = (): MockEditGraphQLSubscriptions => {

--- a/spec/__support__/filesync.ts
+++ b/spec/__support__/filesync.ts
@@ -446,7 +446,9 @@ export const makeSyncScenario = async ({
     emitGadgetChanges: async (changes) => {
       expect(changes.remoteFilesVersion).toBe(String(gadgetFilesVersion + 1n));
       await processGadgetChanges(changes);
-      mockEditGraphQLSubs.expectSubscription(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION).emitResult({ data: { remoteFileSyncEvents: changes } });
+      await mockEditGraphQLSubs
+        .expectSubscription(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION)
+        .emitResult({ data: { remoteFileSyncEvents: changes } });
     },
 
     expectGadgetChangesSubscription: () => mockEditGraphQLSubs.expectSubscription(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION),

--- a/spec/commands/deploy.spec.ts
+++ b/spec/commands/deploy.spec.ts
@@ -46,7 +46,7 @@ describe("deploy", () => {
 
     const publishStatus = mockEditGraphQL.expectSubscription(REMOTE_SERVER_CONTRACT_STATUS_SUBSCRIPTION);
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -84,7 +84,7 @@ describe("deploy", () => {
 
     const publishStatus = mockEditGraphQL.expectSubscription(REMOTE_SERVER_CONTRACT_STATUS_SUBSCRIPTION);
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -112,7 +112,7 @@ describe("deploy", () => {
 
     vi.spyOn(prompt, "select").mockResolvedValue(Action.DEPLOY_ANYWAYS);
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -122,7 +122,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -132,7 +132,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -142,7 +142,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -152,7 +152,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -162,7 +162,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -172,7 +172,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -211,7 +211,7 @@ describe("deploy", () => {
     await deploy(ctx);
     const publishStatus = mockEditGraphQL.expectSubscription(REMOTE_SERVER_CONTRACT_STATUS_SUBSCRIPTION);
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -221,7 +221,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -231,7 +231,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -241,7 +241,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -251,7 +251,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -261,7 +261,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -271,7 +271,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -281,7 +281,7 @@ describe("deploy", () => {
       },
     });
 
-    publishStatus.emitResult({
+    await publishStatus.emitResult({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -321,7 +321,7 @@ describe("deploy", () => {
     await deploy(ctx);
     const publishStatus = mockEditGraphQL.expectSubscription(REMOTE_SERVER_CONTRACT_STATUS_SUBSCRIPTION);
 
-    publishStatus.emitError(error);
+    await publishStatus.emitError(error);
 
     expectStdout().toMatchInlineSnapshot(`
       "

--- a/spec/commands/sync.spec.ts
+++ b/spec/commands/sync.spec.ts
@@ -1233,7 +1233,7 @@ describe("sync", () => {
     const error = new EditGraphQLError(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION, "test");
 
     const gadgetChangesSubscription = expectGadgetChangesSubscription();
-    gadgetChangesSubscription.emitError(error);
+    await gadgetChangesSubscription.emitError(error);
 
     await expectReportErrorAndExit(error);
 


### PR DESCRIPTION
This adds a `PQueue` inside `EditGraphQL` subscriptions so that we:

1. Process messages in the order we receive them
2. Never process messages in parallel

This allows our GraphQL subscription handlers to be async while still ensuring they run in the expected order. This also helps us write tests where we can `await` the handler of a message rather than watching for external state to change.

None of our current subscriptions need to process messages in parallel, in fact filesync already uses a `PQueue` internal to prevent this from happening. If we ever need to process messages in parallel in the future, we can add a `concurrency` option.
