### PR TITLE
Handle early exit due to deploy progress interruption

### DIFF
--- a/.changeset/weak-pumas-talk.md
+++ b/.changeset/weak-pumas-talk.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Fixes a bug in which users get stuck waiting for deploy progress updates when the deploy has been interrupted.


### PR DESCRIPTION
Ggt `deploy` currently will get stuck if the deploy is interrupted and no more progress updates are sent. We need to handle the case where the websocket connection closes due to a step in the deploy erroring and let the user which step it failed at and exit so they aren't stuck waiting for progress updates.

<img width="546" alt="image" src="https://github.com/gadget-inc/ggt/assets/92458251/67e44593-0204-4d78-97cc-4b170bad49bc">