### PR TITLE
Fix process exit flake

### DIFF
--- a/spec/__support__/filesync.ts
+++ b/spec/__support__/filesync.ts
@@ -5,12 +5,7 @@ import pMap from "p-map";
 import pTimeout from "p-timeout";
 import { expect, vi, type Assertion } from "vitest";
 import { z } from "zod";
-import {
-  FileSyncEncoding,
-  type FileSyncChangedEvent,
-  type FileSyncChangedEventInput,
-  type FileSyncDeletedEventInput,
-} from "../../src/__generated__/graphql.js";
+import { FileSyncEncoding, type FileSyncChangedEventInput, type FileSyncDeletedEventInput } from "../../src/__generated__/graphql.js";
 import {
   FILE_SYNC_COMPARISON_HASHES_QUERY,
   FILE_SYNC_FILES_QUERY,
@@ -357,37 +352,6 @@ export const makeSyncScenario = async ({
   });
 
   const mockEditGraphQLSubs = makeMockEditGraphQLSubscriptions();
-  mockEditGraphQLSubs.mockInitialResult(REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION, async ({ localFilesVersion }) => {
-    log.trace("mocking initial result for remote file sync events", { localFilesVersion });
-
-    const changed = [] as FileSyncChangedEvent[];
-    if (localFilesVersion === "0") {
-      const gadgetFiles = await readDir(gadgetDir.path);
-      for (const [path, content] of Object.entries(gadgetFiles)) {
-        changed.push({
-          path,
-          mode: path.endsWith("/") ? defaultDirMode : defaultFileMode,
-          content: Buffer.from(content).toString(FileSyncEncoding.Base64),
-          encoding: FileSyncEncoding.Base64,
-        });
-      }
-    } else if (localFilesVersion !== String(gadgetFilesVersion)) {
-      // tests should make local files start at version 0 (initial sync)
-      // or the same version as gadget (no changes) because we don't
-      // mimic sending file version diffs
-      throw new Error(`Unexpected local files version: ${localFilesVersion}, expected ${gadgetFilesVersion}`);
-    }
-
-    return {
-      data: {
-        remoteFileSyncEvents: {
-          remoteFilesVersion: String(gadgetFilesVersion),
-          changed,
-          deleted: [],
-        },
-      },
-    };
-  });
 
   return {
     filesync,

--- a/spec/vitest.setup.ts
+++ b/spec/vitest.setup.ts
@@ -43,14 +43,13 @@ beforeEach(async () => {
     throw new Error("prompt.select() should not be called");
   });
 
-  // allow logs to flush before exiting
+  // we don't ever want to actually exit the process during tests so
+  // print the current stack trace so we can see where the exit was
+  // called
   spyOnImplementing(process, "exit", (code) => {
-    setImmediate(() => {
-      process.exit.mockRestore?.();
-      process.exit(code);
-    });
-
-    throw new Error(`process.exit(${code}) called`);
+    process.stderr.write(new Error(`process.exit(${code})`).stack + "\n");
+    process.exit.mockRestore?.();
+    process.exit(code);
   });
 });
 


### PR DESCRIPTION
Removes a race condition that causes the process to exit. I ran into this a lot when running all the tests at once locally.

It was caused by mocking the initial result of a GraphQL subscription. The initial result was resolved out of band and would sometimes cause `Unexpected local files version` during the `writes all received files before stopping` test.

Mocking the initial result of a GraphQL subscription feels like an anti-pattern, and we don't need to do it anymore, so I removed it.