### PR TITLE
Ignore directory permissions

### DIFF
--- a/.changeset/some-weird-name.md
+++ b/.changeset/some-weird-name.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Fix `TooManySyncAttemptsError` when local directory's permissions don't match Gadget's

--- a/spec/services/filesync/hashes.spec.ts
+++ b/spec/services/filesync/hashes.spec.ts
@@ -152,22 +152,28 @@ describe("isEqualHash", () => {
     const sha1 = randomUUID();
     const permissions = 0o777;
 
-    expect(isEqualHash({ sha1, permissions }, { sha1, permissions })).toBe(true);
+    expect(isEqualHash("file.txt", { sha1, permissions }, { sha1, permissions })).toBe(true);
   });
 
   it("returns false if hashes are not equal", () => {
     const sha1 = randomUUID();
     const permissions = 0o777;
 
-    expect(isEqualHash({ sha1, permissions }, { sha1: randomUUID(), permissions })).toBe(false);
-    expect(isEqualHash({ sha1, permissions }, { sha1, permissions: 0o755 })).toBe(false);
+    expect(isEqualHash("file.txt", { sha1, permissions }, { sha1: randomUUID(), permissions })).toBe(false);
+    expect(isEqualHash("file.txt", { sha1, permissions }, { sha1, permissions: 0o755 })).toBe(false);
   });
 
   it("ignores permissions if they are not set", () => {
     const sha1 = randomUUID();
 
-    expect(isEqualHash({ sha1 }, { sha1, permissions: 0o777 })).toBe(true);
-    expect(isEqualHash({ sha1, permissions: 0o777 }, { sha1 })).toBe(true);
+    expect(isEqualHash("file.txt", { sha1 }, { sha1, permissions: 0o777 })).toBe(true);
+    expect(isEqualHash("file.txt", { sha1, permissions: 0o777 }, { sha1 })).toBe(true);
+  });
+
+  it("ignores permissions if it's a directory", () => {
+    const sha1 = randomUUID();
+
+    expect(isEqualHash("dir/", { sha1, permissions: 0o766 }, { sha1, permissions: 0o777 })).toBe(true);
   });
 });
 

--- a/src/services/filesync/conflicts.ts
+++ b/src/services/filesync/conflicts.ts
@@ -36,7 +36,11 @@ export const getConflicts = ({
       continue;
     }
 
-    if ("targetHash" in localChange && "targetHash" in gadgetChange && isEqualHash(localChange.targetHash, gadgetChange.targetHash)) {
+    if (
+      "targetHash" in localChange &&
+      "targetHash" in gadgetChange &&
+      isEqualHash(filepath, localChange.targetHash, gadgetChange.targetHash)
+    ) {
       // local and gadget both created/updated the same file with the same content
       continue;
     }


### PR DESCRIPTION
Simon ran into the `TooManySyncAttemptsError`: https://discord.com/channels/836317518595096598/1169734587899977870/threads/1186047502525399160

```
09:43:15 TRACE hashes: hashes are not equal
  path: '.gadget/'
  aHash:
    sha1: '291c523421f3b1068eab749a5fcba60fc772e159'
    permissions: 509
  bHash:
    sha1: '291c523421f3b1068eab749a5fcba60fc772e159'
    permissions: 493
09:43:15 TRACE hashes: file updated
  path: 'lib/'
  sourceHash:
    sha1: '9d062bafff17ba8b9a1215c4c51485134d509d91'
    permissions: 493
  targetHash:
    sha1: '9d062bafff17ba8b9a1215c4c51485134d509d91'
    permissions: 509
09:43:15 TRACE hashes: file updated
  path: 'delivery/'
  sourceHash:
    sha1: '391cb1e07c5f1f4e3000e0fd125802c7a9b1dc96'
    permissions: 493
  targetHash:
    sha1: '391cb1e07c5f1f4e3000e0fd125802c7a9b1dc96'
    permissions: 509
09:43:15 TRACE hashes: file updated
  path: 'delivery/actions/'
  sourceHash:
    sha1: '326b426f9ac7a96ed6baf62f8838565416d27df8'
    permissions: 493
  targetHash:
    sha1: '326b426f9ac7a96ed6baf62f8838565416d27df8'
    permissions: 509
```

It looks like we're failing to sync directory permissions, so this PR disables that until we can figure out what's wrong and how to fix it. We added the ability to sync permissions so that people can add executable files to their app, which is still possible, so this feels like an acceptable compromise for now.