### PR TITLE
Ignore yarn-error.log from hashes

### DIFF
--- a/.changeset/gentle-cougars-help.md
+++ b/.changeset/gentle-cougars-help.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Fix local `yarn-error.log` causing `TooManySyncAttemptsError`

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 <a href="https://github.com/gadget-inc/ggt/actions/workflows/ci.yml?query=branch%3Amain">
   <img alt="ci workflow status" src="https://img.shields.io/github/actions/workflow/status/gadget-inc/ggt/ci.yml?branch=main&label=ci">
 </a>
-<a href="https://www.npmjs.com/package/@gadgetinc/ggt">
-  <img alt="npm version" src="https://img.shields.io/npm/v/@gadgetinc/ggt">
+<a href="https://www.npmjs.com/package/ggt">
+  <img alt="npm version" src="https://img.shields.io/npm/v/ggt">
 </a>
 <a href="https://discord.gg/nAfNKMdwKh">
   <img alt="discord chat" src="https://img.shields.io/discord/836317518595096598">
@@ -44,7 +44,7 @@
 Run the following to sync a `my-app.gadget.app` application to the `~/gadget/my-app` on your local machine:
 
 ```sh
-npx @gadgetinc/ggt@latest sync --app my-app ~/gadget/my-app
+npx ggt@latest sync ~/gadget/my-app --app=my-app
 ```
 
 With this running in the background, your local `~/gadget/my-app` folder will become two-way synced with your application's filesystem in Gadget's cloud. Changes you make locally will be immediately reflected by your application's API and actions if you re-run them.
@@ -52,7 +52,7 @@ With this running in the background, your local `~/gadget/my-app` folder will be
 ## Usage
 
 ```sh-session
-$ npm install -g @gadgetinc/ggt
+$ npm install -g ggt
 $ ggt
 The command-line interface for Gadget
 

--- a/scripts/generate-readme.ts
+++ b/scripts/generate-readme.ts
@@ -32,7 +32,8 @@ for (const name of AvailableCommands) {
   commands.push(dedent`
     ### \`ggt ${name}\`
 
-    \`\`\`
+    \`\`\`sh-session
+    $ ggt ${name} --help
     ${cmd.usage()}
     \`\`\`
   `);

--- a/spec/commands/__snapshots__/root.spec.ts.snap
+++ b/spec/commands/__snapshots__/root.spec.ts.snap
@@ -38,7 +38,7 @@ exports[`root > when login is given > prints the usage when --help is passed 1`]
 USAGE
   ggt login
 
-EXAMPLES
+EXAMPLE
   $ ggt login
     We've opened Gadget's login page using your default browser.
 
@@ -54,7 +54,7 @@ exports[`root > when login is given > prints the usage when -h is passed 1`] = `
 USAGE
   ggt login
 
-EXAMPLES
+EXAMPLE
   $ ggt login
     We've opened Gadget's login page using your default browser.
 
@@ -70,7 +70,7 @@ exports[`root > when logout is given > prints the usage when --help is passed 1`
 USAGE
   ggt logout
 
-EXAMPLES
+EXAMPLE
   $ ggt logout
     Goodbye
 "
@@ -82,7 +82,7 @@ exports[`root > when logout is given > prints the usage when -h is passed 1`] = 
 USAGE
   ggt logout
 
-EXAMPLES
+EXAMPLE
   $ ggt logout
     Goodbye
 "
@@ -238,7 +238,7 @@ exports[`root > when version is given > prints the usage when --help is passed 1
 USAGE
   ggt version
 
-EXAMPLES
+EXAMPLE
   $ ggt version
     1.2.3
 "
@@ -250,7 +250,7 @@ exports[`root > when version is given > prints the usage when -h is passed 1`] =
 USAGE
   ggt version
 
-EXAMPLES
+EXAMPLE
   $ ggt version
     1.2.3
 "
@@ -262,7 +262,7 @@ exports[`root > when whoami is given > prints the usage when --help is passed 1`
 USAGE
   ggt whoami
 
-EXAMPLES
+EXAMPLE
   $ ggt whoami
     You are logged in as Jane Doe (jane@example.com)
 "
@@ -274,7 +274,7 @@ exports[`root > when whoami is given > prints the usage when -h is passed 1`] = 
 USAGE
   ggt whoami
 
-EXAMPLES
+EXAMPLE
   $ ggt whoami
     You are logged in as Jane Doe (jane@example.com)
 "

--- a/spec/services/filesync/directory.spec.ts
+++ b/spec/services/filesync/directory.spec.ts
@@ -340,6 +340,7 @@ describe("HASHING_IGNORE_PATHS", () => {
       [
         ".gadget/sync.json",
         ".gadget/backup",
+        "yarn-error.log",
       ]
     `);
   });

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -17,7 +17,7 @@ export const usage: Usage = () => sprint`
     {bold USAGE}
       ggt login
 
-    {bold EXAMPLES}
+    {bold EXAMPLE}
       $ ggt login
         We've opened Gadget's login page using your default browser.
 

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -11,7 +11,7 @@ export const usage: Usage = () => sprint`
     {bold USAGE}
       ggt logout
 
-    {bold EXAMPLES}
+    {bold EXAMPLE}
       $ ggt logout
         Goodbye
 `;

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -11,7 +11,7 @@ export const usage: Usage = () => sprint`
   {bold USAGE}
     ggt version
 
-  {bold EXAMPLES}
+  {bold EXAMPLE}
     $ ggt version
       ${config.version}
 `;

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -11,7 +11,7 @@ export const usage: Usage = () => sprint`
     {bold USAGE}
       ggt whoami
 
-    {bold EXAMPLES}
+    {bold EXAMPLE}
       $ ggt whoami
         You are logged in as Jane Doe (jane@example.com)
 `;

--- a/src/services/filesync/directory.ts
+++ b/src/services/filesync/directory.ts
@@ -24,7 +24,7 @@ export const ALWAYS_IGNORE_PATHS = [".DS_Store", "node_modules", ".git"] as cons
  *
  * NOTE: This is the _only_ thing that is allowed to be different between gadget and ggt.
  */
-export const HASHING_IGNORE_PATHS = [".gadget/sync.json", ".gadget/backup"] as const;
+export const HASHING_IGNORE_PATHS = [".gadget/sync.json", ".gadget/backup", "yarn-error.log"] as const;
 
 /**
  * Represents a directory that is being synced.


### PR DESCRIPTION
Another user ran into the `TooManySyncAttemptsError`:
https://discord.com/channels/836317518595096598/1186331446516908164

![image](https://github.com/gadget-inc/ggt/assets/21965521/3d260a53-9c4d-4f9e-89b3-97e2704c6389)

This is happening because we don't include `yarn-error.log` in hashes gadget side, so ggt keeps thinking it doesn't exist and wants to create it.

This PR ignores `yarn-error.log` ggt side as well so this doesn't happen anymore.