### PR TITLE
Rename ParentResource to ParentApiIdentifier

### DIFF
--- a/.changeset/smart-cherries-complain.md
+++ b/.changeset/smart-cherries-complain.md
@@ -2,4 +2,4 @@
 "ggt": patch
 ---
 
-Rename ParentResource in problems message to ParentApiIdentifier
+Rename ParentResource in problems message in ggt deploy to ParentApiIdentifier

--- a/.changeset/smart-cherries-complain.md
+++ b/.changeset/smart-cherries-complain.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Rename ParentResource in problems message to ParentApiIdentifier

--- a/.envrc
+++ b/.envrc
@@ -3,6 +3,7 @@
 use flake
 
 export GGT_SENTRY_ENABLED=0
+export GGT_DEPLOY_PREVIEW=1
 
 export WORKSPACE_ROOT="$PWD"
 export PATH="$WORKSPACE_ROOT/node_modules/.bin/:$PATH"

--- a/spec/commands/__snapshots__/root.spec.ts.snap
+++ b/spec/commands/__snapshots__/root.spec.ts.snap
@@ -1,5 +1,115 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`root > when deploy is given > prints the usage when --help is passed 1`] = `
+"Deploy your Gadget application's development source code to production.
+
+USAGE
+  ggt deploy [DIRECTORY] [--app=<name>]
+
+ARGUMENTS
+  DIRECTORY         The directory to sync files to and deploy (default: \\".\\")
+
+FLAGS
+  -a, --app=<name>  The Gadget application to deploy
+      --force       Deploy the Gadget application regardless of any issues it may have
+
+DESCRIPTION
+  Deploy allows you to deploy your current Gadget application in development to production.
+  
+  It detects if local files are up to date with remote and if the Gadget application 
+  is in a deployable state. If there are any issues, it will display them and ask if 
+  you would like to deploy anyways. 
+  
+  Note:
+    • If local files are not up to date or have not recently been synced with remote ones,
+      you will be prompted to run a one-time sync to ensure the files remain consistent with 
+      what is on the remote. 
+    • You may wish to keep ggt sync running in the background before trying to run ggt deploy
+
+EXAMPLE    
+  $ ggt deploy ~/gadget/example --app example
+  
+  App         example
+  Editor      https://example.gadget.app/edit
+  Playground  https://example.gadget.app/api/graphql/playground
+  Docs        https://docs.gadget.dev/api/example
+
+  Endpoints
+    • https://example.gadget.app
+    • https://example--development.gadget.app
+  
+  
+  Building frontend assets ...
+  ✔ DONE
+  
+  Setting up database ...
+  ✔ DONE
+  
+  Copying development ...
+  ✔ DONE
+  
+  Restarting app ...
+  ✔ DONE
+  
+  Deploy completed. Good bye!
+"
+`;
+
+exports[`root > when deploy is given > prints the usage when -h is passed 1`] = `
+"Deploy your Gadget application's development source code to production.
+
+USAGE
+  ggt deploy [DIRECTORY] [--app=<name>]
+
+ARGUMENTS
+  DIRECTORY         The directory to sync files to and deploy (default: \\".\\")
+
+FLAGS
+  -a, --app=<name>  The Gadget application to deploy
+      --force       Deploy the Gadget application regardless of any issues it may have
+
+DESCRIPTION
+  Deploy allows you to deploy your current Gadget application in development to production.
+  
+  It detects if local files are up to date with remote and if the Gadget application 
+  is in a deployable state. If there are any issues, it will display them and ask if 
+  you would like to deploy anyways. 
+  
+  Note:
+    • If local files are not up to date or have not recently been synced with remote ones,
+      you will be prompted to run a one-time sync to ensure the files remain consistent with 
+      what is on the remote. 
+    • You may wish to keep ggt sync running in the background before trying to run ggt deploy
+
+EXAMPLE    
+  $ ggt deploy ~/gadget/example --app example
+  
+  App         example
+  Editor      https://example.gadget.app/edit
+  Playground  https://example.gadget.app/api/graphql/playground
+  Docs        https://docs.gadget.dev/api/example
+
+  Endpoints
+    • https://example.gadget.app
+    • https://example--development.gadget.app
+  
+  
+  Building frontend assets ...
+  ✔ DONE
+  
+  Setting up database ...
+  ✔ DONE
+  
+  Copying development ...
+  ✔ DONE
+  
+  Restarting app ...
+  ✔ DONE
+  
+  Deploy completed. Good bye!
+"
+`;
+
 exports[`root > when list is given > prints the usage when --help is passed 1`] = `
 "List the apps available to the currently logged in user.
 

--- a/src/__generated__/edit.graphql
+++ b/src/__generated__/edit.graphql
@@ -2,7 +2,8 @@
 ======================================================
 THIS IS A GENERATED FILE! DO NOT EDIT IT MANUALLY!
 
-You can find the original file in the gadget repository
+This is copied from the gadget repository at packages/api/src/__generated__/edit.graphql
+We manually copy in new versions when we need to change it.
 ======================================================
 """
 
@@ -197,6 +198,7 @@ type PublishIssue {
 }
 
 type PublishIssueNode {
+  apiIdentifier: String
   fieldType: String
   key: String!
   name: String
@@ -222,6 +224,7 @@ type Query {
   identifySupportConversation: IdentifySupportConversationResult
   listContributors: [ContributorResult!]! @deprecated(reason: "use team")
   logsSearch(direction: String, end: DateTime, limit: Int, query: String!, start: DateTime, step: Int): LogSearchResult!
+  publishIssues: [PublishIssue!]!
   remoteFilesVersion: String!
   roles: [GadgetRole!]!
   runTestSupportFunction: JSON

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -333,6 +333,7 @@ export type PublishIssue = {
 
 export type PublishIssueNode = {
   __typename?: 'PublishIssueNode';
+  apiIdentifier?: Maybe<Scalars['String']['output']>;
   fieldType?: Maybe<Scalars['String']['output']>;
   key: Scalars['String']['output'];
   name?: Maybe<Scalars['String']['output']>;
@@ -361,6 +362,7 @@ export type Query = {
   /** @deprecated use team */
   listContributors: Array<ContributorResult>;
   logsSearch: LogSearchResult;
+  publishIssues: Array<PublishIssue>;
   remoteFilesVersion: Scalars['String']['output'];
   roles: Array<GadgetRole>;
   runTestSupportFunction?: Maybe<Scalars['JSON']['output']>;
@@ -611,4 +613,4 @@ export type PublishStatusSubscriptionVariables = Exact<{
 }>;
 
 
-export type PublishStatusSubscription = { __typename?: 'Subscription', publishStatus?: { __typename?: 'PublishStatusState', remoteFilesVersion: string, progress: string, issues: Array<{ __typename?: 'PublishIssue', severity: string, message: string, node?: { __typename?: 'PublishIssueNode', type: string, key: string, name?: string | null, fieldType?: string | null, parentKey?: string | null, parentApiIdentifier?: string | null } | null }> } | null };
+export type PublishStatusSubscription = { __typename?: 'Subscription', publishStatus?: { __typename?: 'PublishStatusState', remoteFilesVersion: string, progress: string, issues: Array<{ __typename?: 'PublishIssue', severity: string, message: string, node?: { __typename?: 'PublishIssueNode', type: string, key: string, apiIdentifier?: string | null, name?: string | null, fieldType?: string | null, parentKey?: string | null, parentApiIdentifier?: string | null } | null }> } | null };

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -196,7 +196,7 @@ export const command = (async (ctx, firstRun = true) => {
             `
                     • ${message}                                       
                       ${nodeType ? `${nodeType}: ${chalk.cyan(nodeName)}` : ""}                 ${
-                        nodeParent ? `ParentResource: ${chalk.cyan(nodeParent)}` : ""
+                        nodeParent ? `ParentApiIdentifier: ${chalk.cyan(nodeParent)}` : ""
                       }
             `.trim(),
           );

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -189,7 +189,7 @@ export const command = (async (ctx, firstRun = true) => {
         for (const issue of issues) {
           const message = issue.message.replace(/"/g, "");
           const nodeType = issue.node?.type;
-          const nodeName = issue.node?.name;
+          const nodeName = issue.node?.apiIdentifier ?? issue.node?.name;
           const nodeParent = issue.node?.parentApiIdentifier;
 
           log.printlns(

--- a/src/services/app/edit-graphql.ts
+++ b/src/services/app/edit-graphql.ts
@@ -460,6 +460,7 @@ export const REMOTE_SERVER_CONTRACT_STATUS_SUBSCRIPTION = sprint(/* GraphQL */ `
         node {
           type
           key
+          apiIdentifier
           name
           fieldType
           parentKey

--- a/src/services/command/command.ts
+++ b/src/services/command/command.ts
@@ -10,6 +10,11 @@ import type { Context } from "./context.js";
 
 export const AvailableCommands = ["sync", "list", "login", "logout", "whoami", "version"] as const;
 
+// temporarily remove deploy command from available commands while we're working on it
+if (process.env["GGT_DEPLOY_PREVIEW"]) {
+  (AvailableCommands as unknown as string[]).push("deploy");
+}
+
 export type AvailableCommand = (typeof AvailableCommands)[number];
 
 export const isAvailableCommand = (command: string): command is AvailableCommand => {


### PR DESCRIPTION
We don't use `ParentResource` anywhere in Gadget, let's rename it to `ParentApiIdentifier` to match what we actually call that parent resource in practice.

Edit: closing in favor of [1086](https://github.com/gadget-inc/ggt/pull/1086)