### PR TITLE
Refactoring before "Files version mismatch" fix

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -5,7 +5,6 @@ import { REMOTE_SERVER_CONTRACT_STATUS_SUBSCRIPTION } from "../services/app/edit
 import type { ArgsSpec } from "../services/command/arg.js";
 import { type Command, type Usage } from "../services/command/command.js";
 import { FileSync } from "../services/filesync/filesync.js";
-import { isEqualHashes } from "../services/filesync/hashes.js";
 import { select } from "../services/output/prompt.js";
 import { sprint } from "../services/output/sprint.js";
 import { getUserOrLogin } from "../services/user/user.js";
@@ -132,11 +131,8 @@ export const command = (async (ctx, firstRun = true) => {
     log.printlns`App: ${filesync.app.slug}`;
   }
 
-  const { localHashes, gadgetHashes } = await filesync._getHashes();
-
-  const upToDate = isEqualHashes(localHashes, gadgetHashes);
-
-  if (!upToDate) {
+  const { inSync } = await filesync.hashes();
+  if (!inSync) {
     log.printlns`
     Local files have diverged from remote. Run a sync once to converge your files or keep {italic ggt sync} running in the background.
   `;


### PR DESCRIPTION
Just some refactoring to make the #1072 PR smaller
- Renames `_getHashes` -> `hashes`
- Adds `FileSyncHashes` which is what `hashes` returns
- Adds `inSync` to `FileSyncHashes`
- Uses `inSync` inside deploy command
- Splits `sync` into 2 methods:
	- An outer public method that returns when we're in sync
	- An inner private method that performs the steps to get in sync
	- This avoids potential stack overflow exceptions which is more likely to happen during a re-sync that #1072 adds