### PR TITLE
Disable file permission syncing

### DIFF
--- a/.changeset/disable-permission-syncing.md
+++ b/.changeset/disable-permission-syncing.md
@@ -1,0 +1,13 @@
+---
+ggt: patch
+---
+
+Disabled file permission syncing
+
+We have temporarily disabled the ability to sync file permissions between your local filesystem and your Gadget environment. This is due to a bug that is causing permissions not to be set correctly when changed via `ggt sync`. We have created a ticket to track this issue and will re-enable this feature once it is resolved.
+
+In the meantime, if you need to change a file's permissions in your Gadget environment, you can do so by opening the command palette by pressing `Ctrl+Shift+P` (Windows/Linux) or `Cmd+Shift+P` (macOS) and running `chmod` on the file directly.
+
+Here's an example of how to change the permissions on a file named `test.sh` to be executable:
+
+![CleanShot 2023-12-18 at 17 58 10@2x](https://github.com/gadget-inc/ggt/assets/21965521/13f06911-6abe-4ee5-ad63-0446ba65b62f)

--- a/spec/services/filesync/hashes.spec.ts
+++ b/spec/services/filesync/hashes.spec.ts
@@ -148,63 +148,51 @@ describe("withoutUnnecessaryChanges", () => {
 });
 
 describe("isEqualHash", () => {
-  it("returns true if hashes are equal", () => {
+  it("returns true if sha1s are equal", () => {
     const sha1 = randomUUID();
-    const permissions = 0o777;
 
-    expect(isEqualHash("file.txt", { sha1, permissions }, { sha1, permissions })).toBe(true);
+    expect(isEqualHash("file.txt", { sha1 }, { sha1 })).toBe(true);
+    expect(isEqualHash("file.txt", { sha1, permissions: 0o664 }, { sha1, permissions: 0o644 })).toBe(true);
+    expect(isEqualHash("file.txt", { sha1, permissions: 0o644 }, { sha1, permissions: 0o744 })).toBe(true);
+    expect(isEqualHash("file.txt", { sha1 }, { sha1, permissions: 0o644 })).toBe(true);
+    expect(isEqualHash("file.txt", { sha1, permissions: 0o644 }, { sha1 })).toBe(true);
   });
 
-  it("returns false if hashes are not equal", () => {
+  it("returns false if sha1s are not equal", () => {
     const sha1 = randomUUID();
-    const permissions = 0o777;
+    const otherSha1 = randomUUID();
 
-    expect(isEqualHash("file.txt", { sha1, permissions }, { sha1: randomUUID(), permissions })).toBe(false);
-    expect(isEqualHash("file.txt", { sha1, permissions }, { sha1, permissions: 0o755 })).toBe(false);
-  });
-
-  it("ignores permissions if they are not set", () => {
-    const sha1 = randomUUID();
-
-    expect(isEqualHash("file.txt", { sha1 }, { sha1, permissions: 0o777 })).toBe(true);
-    expect(isEqualHash("file.txt", { sha1, permissions: 0o777 }, { sha1 })).toBe(true);
-  });
-
-  it("ignores permissions if it's a directory", () => {
-    const sha1 = randomUUID();
-
-    expect(isEqualHash("dir/", { sha1, permissions: 0o766 }, { sha1, permissions: 0o777 })).toBe(true);
+    expect(isEqualHash("file.txt", { sha1 }, { sha1: otherSha1 })).toBe(false);
+    expect(isEqualHash("file.txt", { sha1, permissions: 0o664 }, { sha1: otherSha1, permissions: 0o644 })).toBe(false);
+    expect(isEqualHash("file.txt", { sha1, permissions: 0o644 }, { sha1: otherSha1, permissions: 0o744 })).toBe(false);
+    expect(isEqualHash("file.txt", { sha1 }, { sha1: otherSha1, permissions: 0o644 })).toBe(false);
+    expect(isEqualHash("file.txt", { sha1, permissions: 0o644 }, { sha1: otherSha1 })).toBe(false);
   });
 });
 
 describe("isEqualHashes", () => {
-  it("returns true if hashes are equal", () => {
+  it("returns true if all sha1s are equal", () => {
     const sha1 = randomUUID();
-    const permissions = 0o777;
 
-    expect(isEqualHashes({ "foo.js": { sha1, permissions } }, { "foo.js": { sha1, permissions } })).toBe(true);
+    expect(isEqualHashes({ "file.txt": { sha1 } }, { "file.txt": { sha1 } })).toBe(true);
+    expect(isEqualHashes({ "file.txt": { sha1, permissions: 0o664 } }, { "file.txt": { sha1, permissions: 0o644 } })).toBe(true);
+    expect(isEqualHashes({ "file.txt": { sha1, permissions: 0o644 } }, { "file.txt": { sha1, permissions: 0o744 } })).toBe(true);
+    expect(isEqualHashes({ "file.txt": { sha1 } }, { "file.txt": { sha1, permissions: 0o644 } })).toBe(true);
+    expect(isEqualHashes({ "file.txt": { sha1, permissions: 0o644 } }, { "file.txt": { sha1 } })).toBe(true);
   });
 
-  it("returns false if hashes are not equal", () => {
+  it("returns true if any sha1s are not equal", () => {
     const sha1 = randomUUID();
-    const permissions = 0o777;
+    const otherSha1 = randomUUID();
 
-    expect(isEqualHashes({ "foo.js": { sha1, permissions } }, { "foo.js": { sha1: randomUUID(), permissions } })).toBe(false);
-    expect(isEqualHashes({ "foo.js": { sha1, permissions } }, { "foo.js": { sha1, permissions: 0o755 } })).toBe(false);
-  });
-
-  it("ignores permissions if they are not set", () => {
-    const sha1 = randomUUID();
-
-    expect(isEqualHashes({ "foo.js": { sha1 } }, { "foo.js": { sha1, permissions: 0o777 } })).toBe(true);
-    expect(isEqualHashes({ "foo.js": { sha1, permissions: 0o777 } }, { "foo.js": { sha1 } })).toBe(true);
-  });
-
-  it("returns false if one of the hashes is missing", () => {
-    const sha1 = randomUUID();
-    const permissions = 0o777;
-
-    expect(isEqualHashes({ "foo.js": { sha1, permissions } }, {})).toBe(false);
-    expect(isEqualHashes({}, { "foo.js": { sha1, permissions } })).toBe(false);
+    expect(isEqualHashes({ "file.txt": { sha1 } }, { "file.txt": { sha1: otherSha1 } })).toBe(false);
+    expect(isEqualHashes({ "file.txt": { sha1, permissions: 0o664 } }, { "file.txt": { sha1: otherSha1, permissions: 0o644 } })).toBe(
+      false,
+    );
+    expect(isEqualHashes({ "file.txt": { sha1, permissions: 0o644 } }, { "file.txt": { sha1: otherSha1, permissions: 0o744 } })).toBe(
+      false,
+    );
+    expect(isEqualHashes({ "file.txt": { sha1 } }, { "file.txt": { sha1: otherSha1, permissions: 0o644 } })).toBe(false);
+    expect(isEqualHashes({ "file.txt": { sha1, permissions: 0o644 } }, { "file.txt": { sha1: otherSha1 } })).toBe(false);
   });
 });

--- a/src/services/filesync/hashes.ts
+++ b/src/services/filesync/hashes.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert";
 import { createLogger } from "../output/log/logger.js";
-import { isNil } from "../util/is.js";
 import { type Create, type Delete, type Update } from "./changes.js";
 import type { Hash, Hashes } from "./directory.js";
 
@@ -132,25 +131,29 @@ export const withoutUnnecessaryChanges = ({ changes, existing }: { changes: Chan
   return necessaryChanges;
 };
 
-export const isEqualHash = (path: string, aHash: Hash, bHash: Hash): boolean => {
-  if (aHash.sha1 !== bHash.sha1) {
-    // the contents are different
-    return false;
-  }
+export const isEqualHash = (_path: string, aHash: Hash, bHash: Hash): boolean => {
+  // FIXME: we're running into issues syncing permissions with Gadget
+  // so we're temporarily disabling this check until we can figure out
+  return aHash.sha1 === bHash.sha1;
 
-  if (path.endsWith("/")) {
-    // it's a directory, so we don't care about permissions
-    return true;
-  }
+  // if (aHash.sha1 !== bHash.sha1) {
+  //   // the contents are different
+  //   return false;
+  // }
 
-  if (isNil(aHash.permissions) || isNil(bHash.permissions)) {
-    // one of the filesystems doesn't support permissions, so ignore them
-    return true;
-  }
+  // if (path.endsWith("/")) {
+  //   // it's a directory, so we don't care about permissions
+  //   return true;
+  // }
 
-  // the contents are the same, and both filesystems support permissions
-  // so ensure the permissions are also the same
-  return aHash.permissions === bHash.permissions;
+  // if (isNil(aHash.permissions) || isNil(bHash.permissions)) {
+  //   // one of the filesystems doesn't support permissions, so ignore them
+  //   return true;
+  // }
+
+  // // the contents are the same, and both filesystems support permissions
+  // // so ensure the permissions are also the same
+  // return aHash.permissions === bHash.permissions;
 };
 
 export const isEqualHashes = (a: Hashes, b: Hashes): boolean => {


### PR DESCRIPTION
A number of users are running into `TooManySyncAttemptsError` because file permissions aren't being updated on Gadget and/or the local filesystem.

I thought the issue was only related to directory permissions, which is what #1075 was supposed to fix, but [Simon proved that a file's permissions aren't being updated either](https://discord.com/channels/836317518595096598/1186047502525399160).