### PR TITLE
Better ggt deploy publish contract error handling and completion

### DIFF
--- a/spec/commands/deploy.spec.ts
+++ b/spec/commands/deploy.spec.ts
@@ -486,12 +486,12 @@ describe("deploy", () => {
   it("exits if the deploy process failed during a deploy step and displays link for logs", async () => {
     await makeSyncScenario({ localFiles: { ".gadget/": "" } });
 
-    const mockEditGraphQL = makeMockEditGraphQLSubscriptions();
+    const mockEditGraphQL = makeMockEditSubscriptions();
 
     await deploy(ctx);
     const publishStatus = mockEditGraphQL.expectSubscription(REMOTE_SERVER_CONTRACT_STATUS_SUBSCRIPTION);
 
-    await publishStatus.emitResult({
+    await publishStatus.emitResponse({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -502,7 +502,7 @@ describe("deploy", () => {
       },
     });
 
-    await publishStatus.emitResult({
+    await publishStatus.emitResponse({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -517,7 +517,7 @@ describe("deploy", () => {
       },
     });
 
-    await publishStatus.emitResult({
+    await publishStatus.emitResponse({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",
@@ -532,7 +532,7 @@ describe("deploy", () => {
       },
     });
 
-    await publishStatus.emitResult({
+    await publishStatus.emitResponse({
       data: {
         publishStatus: {
           remoteFilesVersion: "1",

--- a/spec/commands/deploy.spec.ts
+++ b/spec/commands/deploy.spec.ts
@@ -339,7 +339,7 @@ describe("deploy", () => {
     `);
   });
 
-  it("exits if the subscription unexpected closes due to an Internal Error", async () => {
+  it("exits if the subscription unexpectedly closes due to an Internal Error", async () => {
     await makeSyncScenario({ localFiles: { ".gadget/": "" } });
 
     const mockEditGraphQL = makeMockEditSubscriptions();

--- a/spec/commands/deploy.spec.ts
+++ b/spec/commands/deploy.spec.ts
@@ -70,7 +70,7 @@ describe("deploy", () => {
 
       Issues detected
 
-      • Other Issues 1 issue 
+      • Other Issues 1 issue
          ✖ Add google keys for production
       "
     `);
@@ -110,7 +110,7 @@ describe("deploy", () => {
 
       Issues detected
 
-      • Other Issues 1 issue 
+      • Other Issues 1 issue
          ✖ Add google keys for production
       "
     `);
@@ -228,7 +228,7 @@ describe("deploy", () => {
 
       Issues detected
 
-      • Other Issues 1 issue 
+      • Other Issues 1 issue
          ✖ Add google keys for production
 
       Building frontend assets ...

--- a/spec/commands/deploy.spec.ts
+++ b/spec/commands/deploy.spec.ts
@@ -59,6 +59,7 @@ describe("deploy", () => {
               node: undefined,
             },
           ],
+          status: undefined,
         },
       },
     });
@@ -98,6 +99,7 @@ describe("deploy", () => {
               node: undefined,
             },
           ],
+          status: undefined,
         },
       },
     });
@@ -121,6 +123,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "STARTING",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -131,6 +138,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "BUILDING_ASSETS",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -141,6 +153,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "UPLOADING_ASSETS",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -151,6 +168,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "CONVERGING_STORAGE",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -161,6 +183,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "PUBLISHING_TREE",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -171,6 +198,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "RELOADING_SANDBOX",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -181,6 +213,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "COMPLETED",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -204,7 +241,7 @@ describe("deploy", () => {
 
       Deploy completed. Good bye!
 
-      Cmd/Ctrl + Click: ]8;;undefinedView Logs]8;;
+      Cmd/Ctrl + Click: ]8;;https://test.gadget.app/url/to/logs/with/traceIdView Logs]8;;
       "
     `);
   });
@@ -223,6 +260,7 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "NOT_STARTED",
           issues: [],
+          status: undefined,
         },
       },
     });
@@ -233,6 +271,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "STARTING",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -243,6 +286,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "BUILDING_ASSETS",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -253,6 +301,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "UPLOADING_ASSETS",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -263,6 +316,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "CONVERGING_STORAGE",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -273,6 +331,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "PUBLISHING_TREE",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -283,6 +346,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "RELOADING_SANDBOX",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -293,6 +361,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "COMPLETED",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -311,7 +384,7 @@ describe("deploy", () => {
 
       Deploy completed. Good bye!
 
-      Cmd/Ctrl + Click: ]8;;undefinedView Logs]8;;
+      Cmd/Ctrl + Click: ]8;;https://test.gadget.app/url/to/logs/with/traceIdView Logs]8;;
       "
     `);
   });
@@ -362,6 +435,7 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "NOT_STARTED",
           issues: [],
+          status: undefined,
         },
       },
     });
@@ -372,6 +446,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "STARTING",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -382,6 +461,11 @@ describe("deploy", () => {
           remoteFilesVersion: "1",
           progress: "BUILDING_ASSETS",
           issues: [],
+          status: {
+            code: "Pending",
+            message: undefined,
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
+          },
         },
       },
     });
@@ -427,7 +511,7 @@ describe("deploy", () => {
           status: {
             code: "Pending",
             message: undefined,
-            output: "https://test.gadget.app/url/to/logs/wjth/traceId",
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
           },
         },
       },
@@ -442,7 +526,7 @@ describe("deploy", () => {
           status: {
             code: "Pending",
             message: undefined,
-            output: "https://test.gadget.app/url/to/logs/wjth/traceId",
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
           },
         },
       },
@@ -457,7 +541,7 @@ describe("deploy", () => {
           status: {
             code: "Errored",
             message: "GGT_ASSET_BUILD_FAILED: An error occurred while building production assets",
-            output: "https://test.gadget.app/url/to/logs/wjth/traceId",
+            output: "https://test.gadget.app/url/to/logs/with/traceId",
           },
         },
       },
@@ -471,7 +555,7 @@ describe("deploy", () => {
 
       GGT_ASSET_BUILD_FAILED: An error occurred while building production assets
 
-      Cmd/Ctrl + Click: ]8;;https://test.gadget.app/url/to/logs/wjth/traceIdView Logs]8;;
+      Cmd/Ctrl + Click: ]8;;https://test.gadget.app/url/to/logs/with/traceIdView Logs]8;;
       "
     `);
   });

--- a/spec/commands/deploy.spec.ts
+++ b/spec/commands/deploy.spec.ts
@@ -399,7 +399,7 @@ describe("deploy", () => {
     `);
   });
 
-  it.only("exits if the deploy process failed during a deploy step and displays link for logs", async () => {
+  it("exits if the deploy process failed during a deploy step and displays link for logs", async () => {
     await makeSyncScenario({ localFiles: { ".gadget/": "" } });
 
     const mockEditGraphQL = makeMockEditGraphQLSubscriptions();

--- a/spec/commands/deploy.spec.ts
+++ b/spec/commands/deploy.spec.ts
@@ -200,6 +200,8 @@ describe("deploy", () => {
       Restarting app ...
 
       Deploy completed. Good bye!
+
+      Cmd + Click: ]8;;undefinedView Logs]8;; 
       "
     `);
   });
@@ -305,6 +307,8 @@ describe("deploy", () => {
       Restarting app ...
 
       Deploy completed. Good bye!
+
+      Cmd + Click: ]8;;undefinedView Logs]8;; 
       "
     `);
   });

--- a/src/__generated__/edit.graphql
+++ b/src/__generated__/edit.graphql
@@ -194,6 +194,7 @@ type PublishFileSyncEventsResult {
 type PublishIssue {
   message: String!
   node: PublishIssueNode
+  nodeLabels: [PublishIssueNodeLabel]
   severity: String!
 }
 
@@ -207,10 +208,15 @@ type PublishIssueNode {
   type: String!
 }
 
+type PublishIssueNodeLabel {
+  identifier: String
+  type: String
+}
+
 type PublishStatus {
-  code: String!
+  code: String
   message: String
-  traceIdUrl: String!
+  output: String
 }
 
 type PublishStatusState {

--- a/src/__generated__/edit.graphql
+++ b/src/__generated__/edit.graphql
@@ -207,10 +207,18 @@ type PublishIssueNode {
   type: String!
 }
 
+type PublishStatus {
+  code: String!
+  message: String
+  traceIdUrl: String!
+}
+
 type PublishStatusState {
   issues: [PublishIssue!]!
   progress: String!
+  publishStarted: Boolean!
   remoteFilesVersion: String!
+  status: PublishStatus
 }
 
 type Query {

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -342,11 +342,20 @@ export type PublishIssueNode = {
   type: Scalars['String']['output'];
 };
 
+export type PublishStatus = {
+  __typename?: 'PublishStatus';
+  code: Scalars['String']['output'];
+  message?: Maybe<Scalars['String']['output']>;
+  traceIdUrl: Scalars['String']['output'];
+};
+
 export type PublishStatusState = {
   __typename?: 'PublishStatusState';
   issues: Array<PublishIssue>;
   progress: Scalars['String']['output'];
+  publishStarted: Scalars['Boolean']['output'];
   remoteFilesVersion: Scalars['String']['output'];
+  status?: Maybe<PublishStatus>;
 };
 
 export type Query = {
@@ -613,4 +622,4 @@ export type PublishStatusSubscriptionVariables = Exact<{
 }>;
 
 
-export type PublishStatusSubscription = { __typename?: 'Subscription', publishStatus?: { __typename?: 'PublishStatusState', remoteFilesVersion: string, progress: string, issues: Array<{ __typename?: 'PublishIssue', severity: string, message: string, node?: { __typename?: 'PublishIssueNode', type: string, key: string, apiIdentifier?: string | null, name?: string | null, fieldType?: string | null, parentKey?: string | null, parentApiIdentifier?: string | null } | null }> } | null };
+export type PublishStatusSubscription = { __typename?: 'Subscription', publishStatus?: { __typename?: 'PublishStatusState', remoteFilesVersion: string, progress: string, issues: Array<{ __typename?: 'PublishIssue', severity: string, message: string, node?: { __typename?: 'PublishIssueNode', type: string, key: string, apiIdentifier?: string | null, name?: string | null, fieldType?: string | null, parentKey?: string | null, parentApiIdentifier?: string | null } | null }>, status?: { __typename?: 'PublishStatus', code: string, message?: string | null, traceIdUrl: string } | null } | null };

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -328,6 +328,7 @@ export type PublishIssue = {
   __typename?: 'PublishIssue';
   message: Scalars['String']['output'];
   node?: Maybe<PublishIssueNode>;
+  nodeLabels?: Maybe<Array<Maybe<PublishIssueNodeLabel>>>;
   severity: Scalars['String']['output'];
 };
 
@@ -342,11 +343,17 @@ export type PublishIssueNode = {
   type: Scalars['String']['output'];
 };
 
+export type PublishIssueNodeLabel = {
+  __typename?: 'PublishIssueNodeLabel';
+  identifier?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+};
+
 export type PublishStatus = {
   __typename?: 'PublishStatus';
-  code: Scalars['String']['output'];
+  code?: Maybe<Scalars['String']['output']>;
   message?: Maybe<Scalars['String']['output']>;
-  traceIdUrl: Scalars['String']['output'];
+  output?: Maybe<Scalars['String']['output']>;
 };
 
 export type PublishStatusState = {
@@ -622,4 +629,4 @@ export type PublishStatusSubscriptionVariables = Exact<{
 }>;
 
 
-export type PublishStatusSubscription = { __typename?: 'Subscription', publishStatus?: { __typename?: 'PublishStatusState', remoteFilesVersion: string, progress: string, issues: Array<{ __typename?: 'PublishIssue', severity: string, message: string, node?: { __typename?: 'PublishIssueNode', type: string, key: string, apiIdentifier?: string | null, name?: string | null, fieldType?: string | null, parentKey?: string | null, parentApiIdentifier?: string | null } | null }>, status?: { __typename?: 'PublishStatus', code: string, message?: string | null, traceIdUrl: string } | null } | null };
+export type PublishStatusSubscription = { __typename?: 'Subscription', publishStatus?: { __typename?: 'PublishStatusState', remoteFilesVersion: string, progress: string, issues: Array<{ __typename?: 'PublishIssue', severity: string, message: string, node?: { __typename?: 'PublishIssueNode', type: string, key: string, apiIdentifier?: string | null, name?: string | null, fieldType?: string | null, parentKey?: string | null, parentApiIdentifier?: string | null } | null, nodeLabels?: Array<{ __typename?: 'PublishIssueNodeLabel', type?: string | null, identifier?: string | null } | null> | null }>, status?: { __typename?: 'PublishStatus', code?: string | null, message?: string | null, output?: string | null } | null } | null };

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -230,7 +230,7 @@ export const command = (async (ctx, firstRun = true) => {
           for (const [name, nodeArray] of Object.entries(groupedIssues)) {
             ctx.log.println(
               `\n\n • ${chalk.cyan(name)} ${chalk.redBright(
-                `${nodeArray.length === 1 ? `${nodeArray.length} issue` : `${nodeArray.length} issues`}`,
+                nodeArray.length === 1 ? `${nodeArray.length} issue` : `${nodeArray.length} issues`,
               )}${nodeArray
                 .map((e) => {
                   if (!e.node) {
@@ -250,7 +250,7 @@ export const command = (async (ctx, firstRun = true) => {
           if (e.node?.type === "SourceFile") {
             return `${chalk.magentaBright("Typescript")} ${e.message.replace(/[.,]+$/, "")}`;
           }
-          return `${e.message.replace(/[.,]+$/, "")}`;
+          return e.message.replace(/[.,]+$/, "");
         };
 
         const issuesWithNoNode = issues.filter((item) => item.node?.apiIdentifier) as NodeIssue[];

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -226,13 +226,12 @@ export const command = (async (ctx, firstRun = true) => {
       if (firstRun && hasIssues) {
         ctx.log.printlns`{underline Issues detected}`;
 
-        // @typescript-eslint/no-useless-template-literals
         const printIssues = (groupedIssues: GroupedIssues): void => {
           for (const [name, nodeArray] of Object.entries(groupedIssues)) {
             ctx.log.println(
               `\n\n • ${chalk.cyan(name)} ${chalk.redBright(
                 `${nodeArray.length === 1 ? `${nodeArray.length} issue` : `${nodeArray.length} issues`}`,
-              )} ${nodeArray
+              )}${nodeArray
                 .map((e) => {
                   if (!e.node) {
                     return `\n\t   ${chalk.red("✖")} ${e.message}`;
@@ -288,7 +287,7 @@ export const command = (async (ctx, firstRun = true) => {
 
         const handleCompletion = (message: string | null | undefined, color: string): void => {
           spinner.stopAndPersist({
-            symbol: color === "red" ? `${chalk.red("✖")}` : `${chalk.greenBright("✔")}`,
+            symbol: color === "red" ? chalk.red("✖") : chalk.greenBright("✔"),
             text: color === "red" ? "Failed" : "DONE",
           });
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -163,7 +163,8 @@ export const command = (async (ctx, firstRun = true) => {
       return;
     },
     onData: async ({ publishStatus }): Promise<void> => {
-      const { progress, issues } = publishStatus ?? {};
+      // console.log("[jenny] data", publishStatus);
+      const { progress, issues, status } = publishStatus ?? {};
 
       const hasIssues = issues?.length;
 
@@ -208,9 +209,17 @@ export const command = (async (ctx, firstRun = true) => {
 
         firstRun = false;
       } else {
+        if (status?.code === "Errored") {
+          spinner.fail("Failed");
+          log.printlns`{red ${status.message}}`;
+          log.println(`TraceID url: ${status.traceIdUrl}`);
+          unsubscribe();
+          return;
+        }
+
         if (progress === AppDeploymentSteps.COMPLETED) {
           spinner.succeed("DONE");
-          ctx.log.printlns("Deploy completed. Good bye!");
+          ctx.log.printlns`{green Deploy completed. Good bye!}`;
           unsubscribe();
           return;
         }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -212,7 +212,11 @@ export const command = (async (ctx, firstRun = true) => {
         if (status?.code === "Errored") {
           spinner.fail("Failed");
           log.printlns`{red ${status.message}}`;
-          log.println(`TraceID url: ${status.traceIdUrl}`);
+          log.printlns(
+            `
+            Cmd + Click: \u001b]8;;${status?.traceIdUrl}\u0007View Logs\u001b]8;;\u0007 
+            `,
+          );
           unsubscribe();
           return;
         }
@@ -220,6 +224,11 @@ export const command = (async (ctx, firstRun = true) => {
         if (progress === AppDeploymentSteps.COMPLETED) {
           spinner.succeed("DONE");
           ctx.log.printlns`{green Deploy completed. Good bye!}`;
+          ctx.log.printlns(
+            `
+            Cmd + Click: \u001b]8;;${status?.traceIdUrl}\u0007View Logs\u001b]8;;\u0007 
+            `,
+          );
           unsubscribe();
           return;
         }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -283,6 +283,8 @@ export const command = (async (ctx, firstRun = true) => {
 
         firstRun = false;
       } else {
+        const publishStatus = status ? (status as PublishStatus) : undefined;
+
         const handleCompletion = (message: string | null | undefined, color: string): void => {
           spinner.stopAndPersist({
             symbol: color === "red" ? `${chalk.red("✖")}` : `${chalk.greenBright("✔")}`,
@@ -290,12 +292,13 @@ export const command = (async (ctx, firstRun = true) => {
           });
 
           log.printlns(color === "red" ? chalk.red(message) : chalk.green(message));
-
-          log.printlns(`Cmd/Ctrl + Click: \u001b]8;;${status?.output}\u0007View Logs\u001b]8;;\u0007`);
+          if (publishStatus?.output) {
+            log.printlns(`Cmd/Ctrl + Click: \u001b]8;;${publishStatus.output}\u0007View Logs\u001b]8;;\u0007`);
+          }
           unsubscribe();
         };
 
-        if ((status as PublishStatus).code === "Errored") {
+        if (publishStatus && "code" in publishStatus && publishStatus.code === "Errored") {
           handleCompletion((status as PublishStatus).message, "red");
           return;
         }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -226,6 +226,7 @@ export const command = (async (ctx, firstRun = true) => {
       if (firstRun && hasIssues) {
         ctx.log.printlns`{underline Issues detected}`;
 
+        // @typescript-eslint/no-useless-template-literals
         const printIssues = (groupedIssues: GroupedIssues): void => {
           for (const [name, nodeArray] of Object.entries(groupedIssues)) {
             ctx.log.println(

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -219,7 +219,6 @@ export const command = (async (ctx, firstRun = true) => {
       return;
     },
     onData: async ({ publishStatus }): Promise<void> => {
-      console.log("[jenny] publishStatus", publishStatus);
       const { progress, issues, status } = publishStatus ?? {};
 
       const hasIssues = issues?.length;

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -299,7 +299,7 @@ export const command = (async (ctx, firstRun = true) => {
         };
 
         if (publishStatus && "code" in publishStatus && publishStatus.code === "Errored") {
-          handleCompletion((status as PublishStatus).message, "red");
+          handleCompletion(publishStatus.message, "red");
           return;
         }
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -228,7 +228,7 @@ export const command = (async (ctx, firstRun = true) => {
 
         const printIssues = (groupedIssues: GroupedIssues): void => {
           for (const [name, nodeArray] of Object.entries(groupedIssues)) {
-            log.println(
+            ctx.log.println(
               `\n\n • ${chalk.cyan(name)} ${chalk.redBright(
                 `${nodeArray.length === 1 ? `${nodeArray.length} issue` : `${nodeArray.length} issues`}`,
               )} ${nodeArray
@@ -291,9 +291,9 @@ export const command = (async (ctx, firstRun = true) => {
             text: color === "red" ? "Failed" : "DONE",
           });
 
-          log.printlns(color === "red" ? chalk.red(message) : chalk.green(message));
+          ctx.log.printlns(color === "red" ? chalk.red(message) : chalk.green(message));
           if (publishStatus?.output) {
-            log.printlns(`Cmd/Ctrl + Click: \u001b]8;;${publishStatus.output}\u0007View Logs\u001b]8;;\u0007`);
+            ctx.log.printlns(`Cmd/Ctrl + Click: \u001b]8;;${publishStatus.output}\u0007View Logs\u001b]8;;\u0007`);
           }
           unsubscribe();
         };

--- a/src/services/app/edit/operation.ts
+++ b/src/services/app/edit/operation.ts
@@ -170,11 +170,15 @@ export const REMOTE_SERVER_CONTRACT_STATUS_SUBSCRIPTION = sprint(/* GraphQL */ `
           parentKey
           parentApiIdentifier
         }
+        nodeLabels {
+          type
+          identifier
+        }
       }
       status {
         code
         message
-        traceIdUrl
+        output
       }
     }
   }

--- a/src/services/app/edit/operation.ts
+++ b/src/services/app/edit/operation.ts
@@ -171,6 +171,11 @@ export const REMOTE_SERVER_CONTRACT_STATUS_SUBSCRIPTION = sprint(/* GraphQL */ `
           parentApiIdentifier
         }
       }
+      status {
+        code
+        message
+        traceIdUrl
+      }
     }
   }
 `) as GraphQLSubscription<PublishStatusSubscription, PublishStatusSubscriptionVariables>;


### PR DESCRIPTION
Updates to ggt deploy:

#### Improved error handling
- Previously, if a deploy errored over on Gadget server-side, `ggt deploy` would hang indefinitely. This was handled previously by throwing an error inside the `publishStatus` subscription's async iterator to close and signal to the client that the connection was closed. GGT would then receive this signal that the websocket was closed unexpectedly and know to exit.
- Unfortunately though all errors thrown from inside the subscription `next()` iterator are parsed as just `CloseEvent` errors (Internal Error) by the graphql-ws client, there's no way to pass any custom error messages or data (can't find any documentation on this but I've experimented with this a bunch). This data is pretty useful and we want to receive it, as well as some other data like the traceId of the deploy, failure or not!
- So, instead of just throwing a generic `CloseEvent` error, let's pass in some more data to GGT that detail the publish contract status and any error messages that signal the deploy has failed, and handle it how we want!

#### Improved UI
- Deploy issues look more similar to how it is in the editor, issues are grouped by problem type and formatted to look more closely to the editor with labels and tags
- Green text for if the deploy was successful, red for if it was not for easier readability and tracking
- A link will be shown when ggt deploy exits (deployed successfully or not) that will take them to the editor with the appropriate traceId of the deploy and when it was started. If the deploy was successful it will take them to the production logs, if not it will take them to the development logs, which mimic the editor)

Related: [gadget](https://github.com/gadget-inc/gadget/pull/9443)
#### Failed in the middle of a deploy step:
<img width="500" alt="image" src="https://github.com/gadget-inc/ggt/assets/92458251/d5a74aeb-2404-4f0a-8e0e-79d4203c6d90">

#### Successfully deployed:
<img width="500" src="https://github.com/gadget-inc/ggt/assets/92458251/492c9051-be02-441f-a39e-49b0657c2254" />

cc @scott-rc !