### PR TITLE
Propagate context

### DIFF
--- a/spec/__support__/context.ts
+++ b/spec/__support__/context.ts
@@ -4,8 +4,12 @@ import type { ArgsSpec } from "../../src/services/command/arg.js";
 import { AvailableCommands } from "../../src/services/command/command.js";
 import { Context } from "../../src/services/command/context.js";
 
-export const makeContext = <Args extends ArgsSpec>(args?: Args): Context<Args> => {
-  const ctx = new Context(rootArgs, { argv: process.argv.slice(2), permissive: true });
+export const makeContext = <Args extends ArgsSpec>(args: Args = {} as Args, argv?: string[]): Context<Args> => {
+  if (argv) {
+    process.argv = ["node", "ggt", ...argv];
+  }
+
+  const ctx = Context.init({ args: rootArgs, argv: process.argv.slice(2), permissive: true });
 
   // replicate the root command's behavior of shifting the command name
   // from the args
@@ -14,5 +18,5 @@ export const makeContext = <Args extends ArgsSpec>(args?: Args): Context<Args> =
     expect(AvailableCommands).toContain(cmd);
   }
 
-  return ctx.extend({ args, logName: cmd });
+  return ctx.extend({ args, name: cmd });
 };

--- a/spec/__support__/filesync.ts
+++ b/spec/__support__/filesync.ts
@@ -11,6 +11,7 @@ import {
   type FileSyncDeletedEventInput,
   type MutationPublishFileSyncEventsArgs,
 } from "../../src/__generated__/graphql.js";
+import { args } from "../../src/commands/sync.js";
 import {
   FILE_SYNC_COMPARISON_HASHES_QUERY,
   FILE_SYNC_FILES_QUERY,
@@ -26,8 +27,9 @@ import { noop } from "../../src/services/util/function.js";
 import { isNil } from "../../src/services/util/is.js";
 import { defaults, omit } from "../../src/services/util/object.js";
 import { PromiseSignal } from "../../src/services/util/promise.js";
-import type { PartialExcept } from "../types.js";
+import type { PartialExcept } from "../../src/services/util/types.js";
 import { testApp } from "./app.js";
+import { makeContext } from "./context.js";
 import { log } from "./debug.js";
 import { makeMockEditGraphQLSubscriptions, nockEditGraphQLResponse, type MockEditGraphQLSubscription } from "./edit-graphql.js";
 import { readDir, writeDir, type Files } from "./files.js";
@@ -176,7 +178,10 @@ export const makeSyncScenario = async ({
   }
 
   FileSync.init.mockRestore?.();
-  const filesync = await FileSync.init({ user: testUser, dir: localDir.path, app: testApp.slug, force });
+  const filesync = await FileSync.init({
+    user: testUser,
+    ctx: makeContext(args, ["sync", localDir.path, "--app", testApp.slug, `--force=${force}`]),
+  });
   vi.spyOn(FileSync, "init").mockResolvedValue(filesync);
 
   const processGadgetChanges = async ({

--- a/spec/commands/sync.spec.ts
+++ b/spec/commands/sync.spec.ts
@@ -5,7 +5,7 @@ import nock from "nock";
 import notifier from "node-notifier";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import which from "which";
-import { args, command as sync } from "../../src/commands/sync.js";
+import { args, command as sync, type SyncArgs } from "../../src/commands/sync.js";
 import { EditGraphQLError, REMOTE_FILE_SYNC_EVENTS_SUBSCRIPTION } from "../../src/services/app/edit-graphql.js";
 import { type Context } from "../../src/services/command/context.js";
 import { YarnNotFoundError } from "../../src/services/filesync/error.js";
@@ -20,32 +20,31 @@ import { sleep, timeoutMs } from "../__support__/sleep.js";
 import { loginTestUser } from "../__support__/user.js";
 
 describe("sync", () => {
-  let ctx: Context<typeof args>;
+  let ctx: Context<SyncArgs>;
 
   beforeEach(() => {
     loginTestUser();
     nockTestApps();
 
-    process.argv = [
-      "node",
-      "ggt",
-      "sync",
-      testDirPath("local"),
-      "--app",
-      testApp.slug,
-      "--file-push-delay",
-      ms("10ms" /* default 100ms */),
-      "--file-watch-debounce",
-      ms("300ms" /* default 300ms */),
-      "--file-watch-poll-interval",
-      ms("30ms" /* default 3s */),
-      "--file-watch-poll-timeout",
-      ms("20ms" /* default 20s */),
-      "--file-watch-rename-timeout",
-      ms("50ms" /* default 1.25s */),
-    ].map(String);
-
-    ctx = makeContext(args);
+    ctx = makeContext(
+      args,
+      [
+        "sync",
+        testDirPath("local"),
+        "--app",
+        testApp.slug,
+        "--file-push-delay",
+        ms("10ms" /* default 100ms */),
+        "--file-watch-debounce",
+        ms("300ms" /* default 300ms */),
+        "--file-watch-poll-interval",
+        ms("30ms" /* default 3s */),
+        "--file-watch-poll-timeout",
+        ms("20ms" /* default 20s */),
+        "--file-watch-rename-timeout",
+        ms("50ms" /* default 1.25s */),
+      ].map(String),
+    );
   });
 
   afterEach(() => {

--- a/spec/types.ts
+++ b/spec/types.ts
@@ -6,6 +6,4 @@ declare global {
   interface Function extends MockInstance {}
 }
 
-export type PartialExcept<T, K extends keyof T> = Partial<T> & Pick<T, K>;
-
 export {};

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -36,21 +36,15 @@ export const rootUsage: Usage = () => sprint`
 `;
 
 export const rootArgs = {
-  "--help": {
-    type: Boolean,
-    alias: "-h",
-  },
-  "--verbose": {
-    type: arg.COUNT,
-    alias: ["-v", "--debug"],
-  },
-  "--json": {
-    type: Boolean,
-  },
+  "--help": { type: Boolean, alias: "-h" },
+  "--verbose": { type: arg.COUNT, alias: ["-v", "--debug"] },
+  "--json": { type: Boolean },
 } satisfies ArgsSpec;
 
+export type RootArgs = typeof rootArgs;
+
 export const command = async (): Promise<void> => {
-  const ctx = new Context(rootArgs, { argv: process.argv.slice(2), permissive: true });
+  const ctx = Context.init({ args: rootArgs, argv: process.argv.slice(2), permissive: true });
 
   await warnIfUpdateAvailable();
 
@@ -80,7 +74,7 @@ export const command = async (): Promise<void> => {
     process.exit(1);
   }
 
-  const { usage, command, args } = await importCommand(cmd);
+  const { usage, command, args = {} } = await importCommand(cmd);
 
   if (ctx.args["--help"]) {
     log.println(usage());
@@ -88,7 +82,7 @@ export const command = async (): Promise<void> => {
   }
 
   try {
-    await command(ctx.extend({ args, logName: cmd }));
+    await command(ctx.extend({ args, name: cmd }));
   } catch (error) {
     await reportErrorAndExit(error);
   }

--- a/src/services/util/types.ts
+++ b/src/services/util/types.ts
@@ -1,0 +1,3 @@
+import type { Simplify } from "type-fest";
+
+export type PartialExcept<T, K extends keyof T> = Simplify<Partial<T> & Pick<T, K>>;


### PR DESCRIPTION
In order to implement #1072, I'm going to need access to the current `Context` inside the `FileSync` class, so this PR propagates the context down to it.

This also cleans up the `Context` class, adds docs, and makes deploy use the `Context`'s logger instead of `FileSync`'s.