### PR TITLE
Improve Usage

### DIFF
--- a/.changeset/improve-usage.md
+++ b/.changeset/improve-usage.md
@@ -1,0 +1,7 @@
+---
+"ggt": patch
+---
+
+ggt can differentiate between `-h` and `--help`
+
+The `sync` command now prints a short usage message when `-h` is passed and a longer more detailed usage message when `--help` is passed.

--- a/scripts/generate-readme.ts
+++ b/scripts/generate-readme.ts
@@ -6,9 +6,11 @@ import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import remarkToc from "remark-toc";
 import { dedent } from "ts-dedent";
-import { usage } from "../src/commands/root.js";
+import { args, usage } from "../src/commands/root.js";
 import { Commands, importCommand } from "../src/services/command/command.js";
+import { Context } from "../src/services/command/context.js";
 
+const ctx = Context.init({ name: "readme", parse: args, argv: ["-h"] });
 let readme = await fs.readFile("README.md", "utf8");
 
 readme = readme.replace(
@@ -19,7 +21,7 @@ readme = readme.replace(
     \`\`\`sh-session
     $ npm install -g ggt
     $ ggt
-    ${usage()}
+    ${usage(ctx)}
     \`\`\`
 
     $1
@@ -33,8 +35,8 @@ for (const name of Commands) {
     ### \`ggt ${name}\`
 
     \`\`\`sh-session
-    $ ggt ${name} --help
-    ${cmd.usage()}
+    $ ggt ${name} -h
+    ${cmd.usage(ctx)}
     \`\`\`
   `);
 }

--- a/spec/commands/__snapshots__/root.spec.ts.snap
+++ b/spec/commands/__snapshots__/root.spec.ts.snap
@@ -1,112 +1,87 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`root > when deploy is given > prints the usage when --help is passed 1`] = `
-"Deploy your Gadget application's development source code to production.
+"Deploy your development environment to production.
+
+Deploy ensures your directory is in sync with your development
+environment and that it is in a deployable state. If there are any
+issues, it will display them and ask if you would like to deploy
+anyways.
 
 USAGE
-  ggt deploy [DIRECTORY] [--app=<name>]
+  ggt deploy [DIRECTORY] [--app=<name>] [--prefer=<filesystem>] [--force]
+
+EXAMPLES
+
+  $ ggt deploy
+  $ ggt deploy ~/gadget/example
+  $ ggt deploy ~/gadget/example --app=example
+  $ ggt deploy ~/gadget/example --app=example --prefer=local
+  $ ggt deploy ~/gadget/example --app=example --prefer=local --force
 
 ARGUMENTS
-  DIRECTORY         The directory to sync files to and deploy (default: \\".\\")
+
+  DIRECTORY
+    The path to the directory to sync your development environment's
+    files to before deploying it to your production environment.
+    The directory will be created if it does not exist.
+
+    Defaults to the current working directory. (default: \\".\\")
 
 FLAGS
-  -a, --app=<name>  The Gadget application to deploy
-      --force       Deploy the Gadget application regardless of any issues it may have
 
-DESCRIPTION
-  Deploy allows you to deploy your current Gadget application in development to production.
+  -a, --app=<name>
+    The Gadget application to deploy.
 
-  It detects if local files are up to date with remote and if the Gadget application
-  is in a deployable state. If there are any issues, it will display them and ask if
-  you would like to deploy anyways.
+    If not provided, the application will be inferred from the
+    \\".gadget/sync.json\\" file in the chosen directory or any of its
+    parent directories.
 
-  Note:
-    • If local files are not up to date or have not recently been synced with remote ones,
-      you will be prompted to run a one-time sync to ensure the files remain consistent with
-      what is on the remote.
-    • You may wish to keep ggt sync running in the background before trying to run ggt deploy
+    If a \\".gadget/sync.json\\" file is not found, you will be
+    prompted to choose an application from your list of apps.
 
-EXAMPLE
-  $ ggt deploy ~/gadget/example --app example
+  --prefer=<filesystem>
+    Which filesystem's changes to automatically keep when
+    conflicting changes are detected.
 
-  App         example
-  Editor      https://example.gadget.app/edit
-  Playground  https://example.gadget.app/api/graphql/playground
-  Docs        https://docs.gadget.dev/api/example
+    If not provided, deploy will pause when conflicting changes are
+    detected and you will be prompted to choose which changes to
+    keep before deploy resumes.
 
-  Endpoints
-    • https://example.gadget.app
-    • https://example--development.gadget.app
+    Must be one of \\"local\\" or \\"gadget\\".
 
+  --force
+    Deploy your development environment to production regardless
+    of any issues it may have.
 
-  Building frontend assets ...
-  ✔ DONE
-
-  Setting up database ...
-  ✔ DONE
-
-  Copying development ...
-  ✔ DONE
-
-  Restarting app ...
-  ✔ DONE
-
-  Deploy completed. Good bye!
+    These issues may include:
+      • Syntax errors
+      • TypeScript errors
+      • Missing fields that should be present on models
 "
 `;
 
 exports[`root > when deploy is given > prints the usage when -h is passed 1`] = `
-"Deploy your Gadget application's development source code to production.
+"Deploy your development environment to production.
 
 USAGE
-  ggt deploy [DIRECTORY] [--app=<name>]
+  ggt deploy [DIRECTORY]
 
 ARGUMENTS
-  DIRECTORY         The directory to sync files to and deploy (default: \\".\\")
+  DIRECTORY         The directory to sync files from and deploy (default: \\".\\")
+
+EXAMPLES
+  $ ggt deploy
+  $ ggt deploy ~/gadget/example
+  $ ggt deploy ~/gadget/example --app=example
+  $ ggt deploy ~/gadget/example --app=example --prefer=local
 
 FLAGS
-  -a, --app=<name>  The Gadget application to deploy
-      --force       Deploy the Gadget application regardless of any issues it may have
+  -a, --app=<name>          The Gadget application to deploy
+      --prefer=<filesystem>  Prefer \\"local\\" or \\"gadget\\" conflicting changes
+      --force                Deploy regardless of any issues found
 
-DESCRIPTION
-  Deploy allows you to deploy your current Gadget application in development to production.
-
-  It detects if local files are up to date with remote and if the Gadget application
-  is in a deployable state. If there are any issues, it will display them and ask if
-  you would like to deploy anyways.
-
-  Note:
-    • If local files are not up to date or have not recently been synced with remote ones,
-      you will be prompted to run a one-time sync to ensure the files remain consistent with
-      what is on the remote.
-    • You may wish to keep ggt sync running in the background before trying to run ggt deploy
-
-EXAMPLE
-  $ ggt deploy ~/gadget/example --app example
-
-  App         example
-  Editor      https://example.gadget.app/edit
-  Playground  https://example.gadget.app/api/graphql/playground
-  Docs        https://docs.gadget.dev/api/example
-
-  Endpoints
-    • https://example.gadget.app
-    • https://example--development.gadget.app
-
-
-  Building frontend assets ...
-  ✔ DONE
-
-  Setting up database ...
-  ✔ DONE
-
-  Copying development ...
-  ✔ DONE
-
-  Restarting app ...
-  ✔ DONE
-
-  Deploy completed. Good bye!
+Run \\"ggt deploy --help\\" for more information.
 "
 `;
 
@@ -116,13 +91,8 @@ exports[`root > when list is given > prints the usage when --help is passed 1`] 
 USAGE
   ggt list
 
-EXAMPLE
+EXAMPLES
   $ ggt list
-    Slug    Domain
-    ─────── ──────────────────
-    my-app  my-app.gadget.app
-    example example.gadget.app
-    test    test.gadget.app
 "
 `;
 
@@ -132,13 +102,8 @@ exports[`root > when list is given > prints the usage when -h is passed 1`] = `
 USAGE
   ggt list
 
-EXAMPLE
+EXAMPLES
   $ ggt list
-    Slug    Domain
-    ─────── ──────────────────
-    my-app  my-app.gadget.app
-    example example.gadget.app
-    test    test.gadget.app
 "
 `;
 
@@ -148,13 +113,8 @@ exports[`root > when login is given > prints the usage when --help is passed 1`]
 USAGE
   ggt login
 
-EXAMPLE
+EXAMPLES
   $ ggt login
-    We've opened Gadget's login page using your default browser.
-
-    Please log in and then return to this terminal.
-
-    Hello, Jane Doe (jane@example.com)
 "
 `;
 
@@ -164,13 +124,8 @@ exports[`root > when login is given > prints the usage when -h is passed 1`] = `
 USAGE
   ggt login
 
-EXAMPLE
+EXAMPLES
   $ ggt login
-    We've opened Gadget's login page using your default browser.
-
-    Please log in and then return to this terminal.
-
-    Hello, Jane Doe (jane@example.com)
 "
 `;
 
@@ -180,9 +135,8 @@ exports[`root > when logout is given > prints the usage when --help is passed 1`
 USAGE
   ggt logout
 
-EXAMPLE
+EXAMPLES
   $ ggt logout
-    Goodbye
 "
 `;
 
@@ -192,89 +146,109 @@ exports[`root > when logout is given > prints the usage when -h is passed 1`] = 
 USAGE
   ggt logout
 
-EXAMPLE
+EXAMPLES
   $ ggt logout
-    Goodbye
 "
 `;
 
 exports[`root > when sync is given > prints the usage when --help is passed 1`] = `
-"Sync your Gadget environment's source code with your local filesystem.
+"Sync your local filesystem with your Gadget environment's
+filesystem in real-time.
+
+While ggt sync is running, local file changes are immediately
+reflected within Gadget, while files that are changed in Gadget are
+immediately saved to your local filesystem.
+
+Ideal for:
+  • Local development with editors like VSCode
+  • Storing source code in a Git repository like GitHub
+
+Sync looks for a \\".ignore\\" file to exclude files and directories
+from being synced. The format is identical to Git's.
+
+These files are always ignored:
+  • .DS_Store
+  • .gadget
+  • .git
+  • node_modules
+
+Note:
+  • Sync only works with your development environment
+  • Avoid deleting or moving all your files while sync is running
+  • Gadget only supports Yarn v1 for dependency installation
+
+https://docs.gadget.dev/guides/development-tools/cli#filesync
 
 USAGE
-  ggt sync [DIRECTORY]
+
+  ggt sync [DIRECTORY] [--app=<name>] [--prefer=<filesystem>] [--once] [--force]
+
+EXAMPLES
+
+  $ ggt sync
+  $ ggt sync ~/gadget/example
+  $ ggt sync ~/gadget/example --app=example
+  $ ggt sync ~/gadget/example --app=example --prefer=local --once
+  $ ggt sync ~/gadget/example --app=example --prefer=local --once --force
 
 ARGUMENTS
-  DIRECTORY                  The directory to sync files to (default: \\".\\")
+
+  DIRECTORY
+    The path to the directory to sync files to. The directory will
+    be created if it does not exist.
+
+    Defaults to the current working directory. (default: \\".\\")
 
 FLAGS
-  -a, --app=<name>           The Gadget application to sync files to
-      --prefer=<filesystem>  Prefer \\"local\\" or \\"gadget\\" conflicting changes
-      --once                 Sync once and exit
-      --force                Sync regardless of local filesystem state
 
-DESCRIPTION
-  Sync allows you to synchronize your Gadget application's source
-  code with your local filesystem.
+  -a, --app=<name>
+    The Gadget application to sync files to.
 
-  While ggt sync is running, local file changes are immediately
-  reflected within Gadget, while files that are changed in Gadget are
-  immediately saved to your local filesystem.
+    If not provided, the application will be inferred from the
+    \\".gadget/sync.json\\" file in the chosen directory or any of its
+    parent directories.
 
-  Ideal for:
-    • Local development with editors like VSCode
-    • Storing source code in a Git repository like GitHub
+    If a \\".gadget/sync.json\\" file is not found, you will be
+    prompted to choose an application from your list of apps.
 
-  Sync looks for a \\".ignore\\" file to exclude certain files/directories
-  from being synced. The format is identical to Git's.
+  --prefer=<filesystem>
+    Which filesystem's changes to automatically keep when
+    conflicting changes are detected.
 
-  These files are always ignored:
-    • .DS_Store
-    • .gadget
-    • .git
-    • node_modules
+    If not provided, sync will pause when conflicting changes are
+    detected and you will be prompted to choose which changes to
+    keep before sync resumes.
 
-  Note:
-    • Sync only works with your development environment
-    • Avoid deleting/moving all your files while sync is running
-    • Gadget only supports Yarn v1 for dependency installation
+    Must be one of \\"local\\" or \\"gadget\\".
 
-EXAMPLE
-  $ ggt sync ~/gadget/example --app example
+  --once
+    When provided, sync will merge the changes from Gadget with
+    the changes from your local filesystem like it does when
+    started normally, but will then exit instead of continuing to
+    watch for changes.
 
-    App         example
-    Editor      https://example.gadget.app/edit
-    Playground  https://example.gadget.app/api/graphql/playground
-    Docs        https://docs.gadget.dev/api/example
+    Defaults to false.
 
-    Endpoints
-      • https://example.gadget.app
-      • https://example--development.gadget.app
-
-    Watching for file changes... Press Ctrl+C to stop
-
-    → Sent 09:06:25 AM
-    routes/GET-hello.js  + created
-
-    → Sent 09:06:49 AM
-    routes/GET-hello.js  ± updated
-
-    ← Received 09:06:54 AM
-    routes/GET-hello.js  ± updated
-
-    ← Received 09:06:56 AM
-    routes/GET-hello.js  - deleted
-    ^C Stopping... press Ctrl+C again to force
-
-    Goodbye!
+  --force
+    When provided, sync will run regardless of the state of the
+    local filesystem.
 "
 `;
 
 exports[`root > when sync is given > prints the usage when -h is passed 1`] = `
-"Sync your Gadget environment's source code with your local filesystem.
+"Sync your local filesystem with your Gadget environment's
+filesystem in real-time.
+
+https://docs.gadget.dev/guides/development-tools/cli#filesync
 
 USAGE
   ggt sync [DIRECTORY]
+
+EXAMPLES
+  $ ggt sync
+  $ ggt sync ~/gadget/example
+  $ ggt sync ~/gadget/example --app=example
+  $ ggt sync ~/gadget/example --app=example --prefer=local --once
 
 ARGUMENTS
   DIRECTORY                  The directory to sync files to (default: \\".\\")
@@ -285,107 +259,50 @@ FLAGS
       --once                 Sync once and exit
       --force                Sync regardless of local filesystem state
 
-DESCRIPTION
-  Sync allows you to synchronize your Gadget application's source
-  code with your local filesystem.
-
-  While ggt sync is running, local file changes are immediately
-  reflected within Gadget, while files that are changed in Gadget are
-  immediately saved to your local filesystem.
-
-  Ideal for:
-    • Local development with editors like VSCode
-    • Storing source code in a Git repository like GitHub
-
-  Sync looks for a \\".ignore\\" file to exclude certain files/directories
-  from being synced. The format is identical to Git's.
-
-  These files are always ignored:
-    • .DS_Store
-    • .gadget
-    • .git
-    • node_modules
-
-  Note:
-    • Sync only works with your development environment
-    • Avoid deleting/moving all your files while sync is running
-    • Gadget only supports Yarn v1 for dependency installation
-
-EXAMPLE
-  $ ggt sync ~/gadget/example --app example
-
-    App         example
-    Editor      https://example.gadget.app/edit
-    Playground  https://example.gadget.app/api/graphql/playground
-    Docs        https://docs.gadget.dev/api/example
-
-    Endpoints
-      • https://example.gadget.app
-      • https://example--development.gadget.app
-
-    Watching for file changes... Press Ctrl+C to stop
-
-    → Sent 09:06:25 AM
-    routes/GET-hello.js  + created
-
-    → Sent 09:06:49 AM
-    routes/GET-hello.js  ± updated
-
-    ← Received 09:06:54 AM
-    routes/GET-hello.js  ± updated
-
-    ← Received 09:06:56 AM
-    routes/GET-hello.js  - deleted
-    ^C Stopping... press Ctrl+C again to force
-
-    Goodbye!
+  Run \\"ggt sync --help\\" for more information.
 "
 `;
 
 exports[`root > when version is given > prints the usage when --help is passed 1`] = `
-"Print the version of ggt
+"Print the current version of ggt.
 
 USAGE
   ggt version
 
-EXAMPLE
+EXAMPLES
   $ ggt version
-    1.2.3
 "
 `;
 
 exports[`root > when version is given > prints the usage when -h is passed 1`] = `
-"Print the version of ggt
+"Print the current version of ggt.
 
 USAGE
   ggt version
 
-EXAMPLE
+EXAMPLES
   $ ggt version
-    1.2.3
 "
 `;
 
 exports[`root > when whoami is given > prints the usage when --help is passed 1`] = `
-"Show the name and email address of the currently logged in user
+"Show the name and email address of the currently logged in user.
 
 USAGE
   ggt whoami
 
-EXAMPLE
+EXAMPLES
   $ ggt whoami
-    You are logged in as Jane Doe (jane@example.com)
 "
 `;
 
 exports[`root > when whoami is given > prints the usage when -h is passed 1`] = `
-"Show the name and email address of the currently logged in user
+"Show the name and email address of the currently logged in user.
 
 USAGE
   ggt whoami
 
-EXAMPLE
+EXAMPLES
   $ ggt whoami
-    You are logged in as Jane Doe (jane@example.com)
 "
 `;

--- a/spec/commands/root.spec.ts
+++ b/spec/commands/root.spec.ts
@@ -60,7 +60,7 @@ describe("root", () => {
     await expectProcessExit(() => root(makeRootContext()));
 
     expectStdout().toMatchInlineSnapshot(`
-      "The command-line interface for Gadget
+      "The command-line interface for Gadget.
 
       USAGE
         ggt [COMMAND]
@@ -78,7 +78,7 @@ describe("root", () => {
         -v, --verbose  Print verbose output
             --json     Print output as JSON
 
-      For more information on a specific command, use 'ggt [COMMAND] --help'
+      Use \\"ggt [COMMAND] --help\\" for more information about a specific command.
       "
     `);
   });

--- a/spec/services/command/command.spec.ts
+++ b/spec/services/command/command.spec.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { Commands, importCommand, type CommandModule } from "../../../src/services/command/command.js";
+import { makeRootContext } from "../../__support__/context.js";
 
 describe.each(Commands)("%s", (command) => {
   let cmd: CommandModule;
@@ -11,7 +12,7 @@ describe.each(Commands)("%s", (command) => {
   it("has a usage", () => {
     expect(cmd.usage).toBeDefined();
     expect(cmd.usage).toBeInstanceOf(Function);
-    expect(cmd.usage()).toBeTypeOf("string");
+    expect(cmd.usage(makeRootContext())).toBeTypeOf("string");
   });
 
   it("has a command", () => {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -8,59 +8,92 @@ import { select } from "../services/output/prompt.js";
 import { sprint } from "../services/output/sprint.js";
 import { isCloseEvent, isGraphQLErrors } from "../services/util/is.js";
 
-export const usage: Usage = () => sprint`
-    Deploy your Gadget application's development source code to production.
+export const usage: Usage = (ctx) => {
+  if (ctx.args["-h"]) {
+    return sprint`
+      Deploy your development environment to production.
+
+      {bold USAGE}
+        ggt deploy [DIRECTORY]
+
+      {bold ARGUMENTS}
+        DIRECTORY         The directory to sync files from and deploy (default: ".")
+
+      {bold EXAMPLES}
+        $ ggt deploy
+        $ ggt deploy ~/gadget/example
+        $ ggt deploy ~/gadget/example --app=example
+        $ ggt deploy ~/gadget/example --app=example --prefer=local
+
+      {bold FLAGS}
+        -a, --app=<name>          The Gadget application to deploy
+            --prefer=<filesystem>  Prefer "local" or "gadget" conflicting changes
+            --force                Deploy regardless of any issues found
+
+      Run "ggt deploy --help" for more information.
+    `;
+  }
+
+  return sprint`
+    Deploy your development environment to production.
+
+    Deploy ensures your directory is in sync with your development
+    environment and that it is in a deployable state. If there are any
+    issues, it will display them and ask if you would like to deploy
+    anyways.
 
     {bold USAGE}
-      ggt deploy [DIRECTORY] [--app=<name>]
+      ggt deploy [DIRECTORY] [--app=<name>] [--prefer=<filesystem>] [--force]
+
+    {bold EXAMPLES}
+
+      $ ggt deploy
+      $ ggt deploy ~/gadget/example
+      $ ggt deploy ~/gadget/example --app=example
+      $ ggt deploy ~/gadget/example --app=example --prefer=local
+      $ ggt deploy ~/gadget/example --app=example --prefer=local --force
 
     {bold ARGUMENTS}
-      DIRECTORY         The directory to sync files to and deploy (default: ".")
+
+      DIRECTORY
+        The path to the directory to sync your development environment's
+        files to before deploying it to your production environment.
+        The directory will be created if it does not exist.
+
+        Defaults to the current working directory. (default: ".")
 
     {bold FLAGS}
-      -a, --app=<name>  The Gadget application to deploy
-          --force       Deploy the Gadget application regardless of any issues it may have
 
-    {bold DESCRIPTION}
-      Deploy allows you to deploy your current Gadget application in development to production.
+      -a, --app=<name>
+        The Gadget application to deploy.
 
-      It detects if local files are up to date with remote and if the Gadget application
-      is in a deployable state. If there are any issues, it will display them and ask if
-      you would like to deploy anyways.
+        If not provided, the application will be inferred from the
+        ".gadget/sync.json" file in the chosen directory or any of its
+        parent directories.
 
-      Note:
-        • If local files are not up to date or have not recently been synced with remote ones,
-          you will be prompted to run a one-time sync to ensure the files remain consistent with
-          what is on the remote.
-        • You may wish to keep ggt sync running in the background before trying to run ggt deploy
+        If a ".gadget/sync.json" file is not found, you will be
+        prompted to choose an application from your list of apps.
 
-    {bold EXAMPLE}
-      $ ggt deploy ~/gadget/example --app example
+      --prefer=<filesystem>
+        Which filesystem's changes to automatically keep when
+        conflicting changes are detected.
 
-      App         example
-      Editor      https://example.gadget.app/edit
-      Playground  https://example.gadget.app/api/graphql/playground
-      Docs        https://docs.gadget.dev/api/example
+        If not provided, deploy will pause when conflicting changes are
+        detected and you will be prompted to choose which changes to
+        keep before deploy resumes.
 
-      Endpoints
-        • https://example.gadget.app
-        • https://example--development.gadget.app
+        Must be one of "local" or "gadget".
 
+      --force
+        Deploy your development environment to production regardless
+        of any issues it may have.
 
-      Building frontend assets ...
-      ✔ DONE
-
-      Setting up database ...
-      ✔ DONE
-
-      Copying development ...
-      ✔ DONE
-
-      Restarting app ...
-      ✔ DONE
-
-      Deploy completed. Good bye!
+        These issues may include:
+          • Syntax errors
+          • TypeScript errors
+          • Missing fields that should be present on models
 `;
+};
 
 export const args = {
   ...FileSyncArgs,

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -9,13 +9,8 @@ export const usage: Usage = () => sprint`
     {bold USAGE}
       ggt list
 
-    {bold EXAMPLE}
+    {bold EXAMPLES}
       $ ggt list
-        Slug    Domain
-        ─────── ──────────────────
-        my-app  my-app.gadget.app
-        example example.gadget.app
-        test    test.gadget.app
 `;
 
 export const command: Command = async (ctx) => {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -14,13 +14,8 @@ export const usage: Usage = () => sprint`
     {bold USAGE}
       ggt login
 
-    {bold EXAMPLE}
+    {bold EXAMPLES}
       $ ggt login
-        We've opened Gadget's login page using your default browser.
-
-        Please log in and then return to this terminal.
-
-        Hello, Jane Doe (jane@example.com)
 `;
 
 export const login: Command = async (ctx): Promise<void> => {

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -8,9 +8,8 @@ export const usage: Usage = () => sprint`
     {bold USAGE}
       ggt logout
 
-    {bold EXAMPLE}
+    {bold EXAMPLES}
       $ ggt logout
-        Goodbye
 `;
 
 export const command: Command = (ctx) => {

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -9,8 +9,9 @@ import { warnIfUpdateAvailable } from "../services/output/update.js";
 import { sortBySimilar } from "../services/util/collection.js";
 import { isNil } from "../services/util/is.js";
 
-export const usage: Usage = () => sprint`
-    The command-line interface for Gadget
+export const usage: Usage = () => {
+  return sprint`
+    The command-line interface for Gadget.
 
     {bold USAGE}
       ggt [COMMAND]
@@ -28,11 +29,13 @@ export const usage: Usage = () => sprint`
       -v, --verbose  Print verbose output
           --json     Print output as JSON
 
-    For more information on a specific command, use 'ggt [COMMAND] --help'
-`;
+    Use "ggt [COMMAND] --help" for more information about a specific command.
+  `;
+};
 
 export const args = {
-  "--help": { type: Boolean, alias: "-h" },
+  "-h": { type: Boolean },
+  "--help": { type: Boolean },
   "--verbose": { type: arg.COUNT, alias: ["-v", "--debug"] },
   "--json": { type: Boolean },
 } satisfies ArgsDefinition;
@@ -59,7 +62,7 @@ export const command: Command<EmptyObject, EmptyObject> = async (parent): Promis
 
   const cmd = ctx.args._.shift();
   if (isNil(cmd)) {
-    ctx.log.println(usage());
+    ctx.log.println(usage(ctx));
     process.exit(0);
   }
 
@@ -77,8 +80,8 @@ export const command: Command<EmptyObject, EmptyObject> = async (parent): Promis
 
   const subcommand = await importCommand(cmd);
 
-  if (ctx.args["--help"]) {
-    ctx.log.println(subcommand.usage());
+  if (ctx.args["-h"] ?? ctx.args["--help"]) {
+    ctx.log.println(subcommand.usage(ctx));
     process.exit(0);
   }
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -15,24 +15,39 @@ import { sprint } from "../services/output/sprint.js";
 import { debounce } from "../services/util/function.js";
 import { isAbortError } from "../services/util/is.js";
 
-export const usage: Usage = () => sprint`
-  Sync your Gadget environment's source code with your local filesystem.
+export const usage: Usage = (ctx) => {
+  if (ctx.args["-h"]) {
+    return sprint`
+      Sync your local filesystem with your Gadget environment's
+      filesystem in real-time.
 
-  {bold USAGE}
-    ggt sync [DIRECTORY]
+      https://docs.gadget.dev/guides/development-tools/cli#filesync
 
-  {bold ARGUMENTS}
-    DIRECTORY                  The directory to sync files to (default: ".")
+      {bold USAGE}
+        ggt sync [DIRECTORY]
 
-  {bold FLAGS}
-    -a, --app=<name>           The Gadget application to sync files to
-        --prefer=<filesystem>  Prefer "local" or "gadget" conflicting changes
-        --once                 Sync once and exit
-        --force                Sync regardless of local filesystem state
+      {bold EXAMPLES}
+        $ ggt sync
+        $ ggt sync ~/gadget/example
+        $ ggt sync ~/gadget/example --app=example
+        $ ggt sync ~/gadget/example --app=example --prefer=local --once
 
-  {bold DESCRIPTION}
-    Sync allows you to synchronize your Gadget application's source
-    code with your local filesystem.
+      {bold ARGUMENTS}
+        DIRECTORY                  The directory to sync files to (default: ".")
+
+      {bold FLAGS}
+        -a, --app=<name>           The Gadget application to sync files to
+            --prefer=<filesystem>  Prefer "local" or "gadget" conflicting changes
+            --once                 Sync once and exit
+            --force                Sync regardless of local filesystem state
+
+        Run "ggt sync --help" for more information.
+    `;
+  }
+
+  return sprint`
+    Sync your local filesystem with your Gadget environment's
+    filesystem in real-time.
 
     While ggt sync is running, local file changes are immediately
     reflected within Gadget, while files that are changed in Gadget are
@@ -42,7 +57,7 @@ export const usage: Usage = () => sprint`
       • Local development with editors like VSCode
       • Storing source code in a Git repository like GitHub
 
-    Sync looks for a ".ignore" file to exclude certain files/directories
+    Sync looks for a ".ignore" file to exclude files and directories
     from being synced. The format is identical to Git's.
 
     These files are always ignored:
@@ -53,38 +68,66 @@ export const usage: Usage = () => sprint`
 
     Note:
       • Sync only works with your development environment
-      • Avoid deleting/moving all your files while sync is running
+      • Avoid deleting or moving all your files while sync is running
       • Gadget only supports Yarn v1 for dependency installation
 
-  {bold EXAMPLE}
-    $ ggt sync ~/gadget/example --app example
+    https://docs.gadget.dev/guides/development-tools/cli#filesync
 
-      App         example
-      Editor      https://example.gadget.app/edit
-      Playground  https://example.gadget.app/api/graphql/playground
-      Docs        https://docs.gadget.dev/api/example
+    {bold USAGE}
 
-      Endpoints
-        • https://example.gadget.app
-        • https://example--development.gadget.app
+      ggt sync [DIRECTORY] [--app=<name>] [--prefer=<filesystem>] [--once] [--force]
 
-      Watching for file changes... {gray Press Ctrl+C to stop}
+    {bold EXAMPLES}
 
-      → Sent {gray 09:06:25 AM}
-      {greenBright routes/GET-hello.js  + created}
+      $ ggt sync
+      $ ggt sync ~/gadget/example
+      $ ggt sync ~/gadget/example --app=example
+      $ ggt sync ~/gadget/example --app=example --prefer=local --once
+      $ ggt sync ~/gadget/example --app=example --prefer=local --once --force
 
-      → Sent {gray 09:06:49 AM}
-      {blueBright routes/GET-hello.js  ± updated}
+    {bold ARGUMENTS}
 
-      ← Received {gray 09:06:54 AM}
-      {blueBright routes/GET-hello.js  ± updated}
+      DIRECTORY
+        The path to the directory to sync files to. The directory will
+        be created if it does not exist.
 
-      ← Received {gray 09:06:56 AM}
-      {redBright routes/GET-hello.js  - deleted}
-      ^C Stopping... {gray press Ctrl+C again to force}
+        Defaults to the current working directory. (default: ".")
 
-      Goodbye!
-`;
+    {bold FLAGS}
+
+      -a, --app=<name>
+        The Gadget application to sync files to.
+
+        If not provided, the application will be inferred from the
+        ".gadget/sync.json" file in the chosen directory or any of its
+        parent directories.
+
+        If a ".gadget/sync.json" file is not found, you will be
+        prompted to choose an application from your list of apps.
+
+      --prefer=<filesystem>
+        Which filesystem's changes to automatically keep when
+        conflicting changes are detected.
+
+        If not provided, sync will pause when conflicting changes are
+        detected and you will be prompted to choose which changes to
+        keep before sync resumes.
+
+        Must be one of "local" or "gadget".
+
+      --once
+        When provided, sync will merge the changes from Gadget with
+        the changes from your local filesystem like it does when
+        started normally, but will then exit instead of continuing to
+        watch for changes.
+
+        Defaults to false.
+
+      --force
+        When provided, sync will run regardless of the state of the
+        local filesystem.
+  `;
+};
 
 export const args = {
   ...FileSyncArgs,

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -3,14 +3,13 @@ import { config } from "../services/config/config.js";
 import { sprint } from "../services/output/sprint.js";
 
 export const usage: Usage = () => sprint`
-  Print the version of ggt
+  Print the current version of ggt.
 
   {bold USAGE}
     ggt version
 
-  {bold EXAMPLE}
+  {bold EXAMPLES}
     $ ggt version
-      ${config.version}
 `;
 
 export const command: Command = (ctx) => {

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -3,14 +3,13 @@ import { sprint } from "../services/output/sprint.js";
 import { getUser } from "../services/user/user.js";
 
 export const usage: Usage = () => sprint`
-    Show the name and email address of the currently logged in user
+    Show the name and email address of the currently logged in user.
 
     {bold USAGE}
       ggt whoami
 
-    {bold EXAMPLE}
+    {bold EXAMPLES}
       $ ggt whoami
-        You are logged in as Jane Doe (jane@example.com)
 `;
 
 export const command: Command = async (ctx) => {

--- a/src/services/command/command.ts
+++ b/src/services/command/command.ts
@@ -57,7 +57,7 @@ export type CommandModule<Args extends ArgsDefinition = EmptyObject, ParentArgs 
 /**
  * A command's usage is a string that describes how to use the command.
  */
-export type Usage = () => string;
+export type Usage = (ctx: Context) => string;
 
 /**
  * The function that is run when the command is invoked.


### PR DESCRIPTION
This PR:
- Makes our ggt commands able to differentiate between `-h` and `--help`
- Makes the `sync` and `deploy` commands print more detailed information if `--help` is passed
- Updates the `deploy` help text
   - Most of these changes are personal preference, so if you don't like them let me know and I'll revert!

To make this PR easier to read, here's the **before** and **after** for the `sync` and `deploy` help texts.

`ggt sync --help`

<details>
<summary>Before</summary>

```
Sync your Gadget environment's source code with your local filesystem.

USAGE
  ggt sync [DIRECTORY]

ARGUMENTS
  DIRECTORY                  The directory to sync files to (default: ".")

FLAGS
  -a, --app=<name>           The Gadget application to sync files to
      --prefer=<filesystem>  Prefer "local" or "gadget" conflicting changes
      --once                 Sync once and exit
      --force                Sync regardless of local filesystem state

DESCRIPTION
  Sync allows you to synchronize your Gadget application's source
  code with your local filesystem.

  While ggt sync is running, local file changes are immediately
  reflected within Gadget, while files that are changed in Gadget are
  immediately saved to your local filesystem.

  Ideal for:
    • Local development with editors like VSCode
    • Storing source code in a Git repository like GitHub

  Sync looks for a ".ignore" file to exclude certain files/directories
  from being synced. The format is identical to Git's.

  These files are always ignored:
    • .DS_Store
    • .gadget
    • .git
    • node_modules

  Note:
    • Sync only works with your development environment
    • Avoid deleting/moving all your files while sync is running
    • Gadget only supports Yarn v1 for dependency installation

EXAMPLE
  $ ggt sync ~/gadget/example --app example

    App         example
    Editor      https://example.gadget.app/edit
    Playground  https://example.gadget.app/api/graphql/playground
    Docs        https://docs.gadget.dev/api/example

    Endpoints
      • https://example.gadget.app
      • https://example--development.gadget.app

    Watching for file changes... Press Ctrl+C to stop

    → Sent 09:06:25 AM
    routes/GET-hello.js  + created

    → Sent 09:06:49 AM
    routes/GET-hello.js  ± updated

    ← Received 09:06:54 AM
    routes/GET-hello.js  ± updated

    ← Received 09:06:56 AM
    routes/GET-hello.js  - deleted
    ^C Stopping... press Ctrl+C again to force

    Goodbye!
```
</details>

<details>
<summary>After</summary>

`ggt sync -h`

```
Sync your local filesystem with your Gadget environment's
filesystem in real-time.

https://docs.gadget.dev/guides/development-tools/cli#filesync

USAGE
  ggt sync [DIRECTORY]

EXAMPLES
  $ ggt sync
  $ ggt sync ~/gadget/example
  $ ggt sync ~/gadget/example --app=example
  $ ggt sync ~/gadget/example --app=example --prefer=local --once

ARGUMENTS
  DIRECTORY                  The directory to sync files to (default: ".")

FLAGS
  -a, --app=<name>           The Gadget application to sync files to
      --prefer=<filesystem>  Prefer "local" or "gadget" conflicting changes
      --once                 Sync once and exit
      --force                Sync regardless of local filesystem state

  Run "ggt sync --help" for more information.
```

`ggt sync --help`

```
Sync your local filesystem with your Gadget environment's
filesystem in real-time.

While ggt sync is running, local file changes are immediately
reflected within Gadget, while files that are changed in Gadget are
immediately saved to your local filesystem.

Ideal for:
  • Local development with editors like VSCode
  • Storing source code in a Git repository like GitHub

Sync looks for a ".ignore" file to exclude files and directories
from being synced. The format is identical to Git's.

These files are always ignored:
  • .DS_Store
  • .gadget
  • .git
  • node_modules

Note:
  • Sync only works with your development environment
  • Avoid deleting or moving all your files while sync is running
  • Gadget only supports Yarn v1 for dependency installation

https://docs.gadget.dev/guides/development-tools/cli#filesync

USAGE

  ggt sync [DIRECTORY] [--app=<name>] [--prefer=<filesystem>] [--once] [--force]

EXAMPLES

  $ ggt sync
  $ ggt sync ~/gadget/example
  $ ggt sync ~/gadget/example --app=example
  $ ggt sync ~/gadget/example --app=example --prefer=local --once
  $ ggt sync ~/gadget/example --app=example --prefer=local --once --force

ARGUMENTS

  DIRECTORY
    The path to the directory to sync files to. The directory will
    be created if it does not exist.

    Defaults to the current working directory. (default: ".")

FLAGS

  -a, --app=<name>
    The Gadget application to sync files to.

    If not provided, the application will be inferred from the
    ".gadget/sync.json" file in the chosen directory or any of its
    parent directories.

    If a ".gadget/sync.json" file is not found, you will be
    prompted to choose an application from your list of apps.

  --prefer=<filesystem>
    Which filesystem's changes to automatically keep when
    conflicting changes are detected.

    If not provided, sync will pause when conflicting changes are
    detected and you will be prompted to choose which changes to
    keep before sync resumes.

    Must be one of "local" or "gadget".

  --once
    When provided, sync will merge the changes from Gadget with
    the changes from your local filesystem like it does when
    started normally, but will then exit instead of continuing to
    watch for changes.

    Defaults to false.

  --force
    When provided, sync will run regardless of the state of the
    local filesystem.
```

</details>

`ggt deploy --help`

<details>
<summary>Before</summary>

```
Deploy your Gadget application's development source code to production.

USAGE
  ggt deploy [DIRECTORY] [--app=<name>]

ARGUMENTS
  DIRECTORY         The directory to sync files to and deploy (default: ".")

FLAGS
  -a, --app=<name>  The Gadget application to deploy
      --force       Deploy the Gadget application regardless of any issues it may have

DESCRIPTION
  Deploy allows you to deploy your current Gadget application in development to production.

  It detects if local files are up to date with remote and if the Gadget application
  is in a deployable state. If there are any issues, it will display them and ask if
  you would like to deploy anyways.

  Note:
    • If local files are not up to date or have not recently been synced with remote ones,
      you will be prompted to run a one-time sync to ensure the files remain consistent with
      what is on the remote.
    • You may wish to keep ggt sync running in the background before trying to run ggt deploy

EXAMPLE
  $ ggt deploy ~/gadget/example --app example

  App         example
  Editor      https://example.gadget.app/edit
  Playground  https://example.gadget.app/api/graphql/playground
  Docs        https://docs.gadget.dev/api/example

  Endpoints
    • https://example.gadget.app
    • https://example--development.gadget.app


  Building frontend assets ...
  ✔ DONE

  Setting up database ...
  ✔ DONE

  Copying development ...
  ✔ DONE

  Restarting app ...
  ✔ DONE

  Deploy completed. Good bye!
```
</details>

<details>
<summary>After</summary>

`ggt deploy -h`

```
Deploy your development environment to production.

USAGE
  ggt deploy [DIRECTORY]

ARGUMENTS
  DIRECTORY         The directory to sync files from and deploy (default: ".")

EXAMPLES
  $ ggt deploy
  $ ggt deploy ~/gadget/example
  $ ggt deploy ~/gadget/example --app=example
  $ ggt deploy ~/gadget/example --app=example --prefer=local

FLAGS
  -a, --app=<name>          The Gadget application to deploy
      --prefer=<filesystem>  Prefer "local" or "gadget" conflicting changes
      --force                Deploy regardless of any issues found

Run "ggt deploy --help" for more information.
```

`ggt deploy --help`

```
Deploy your development environment to production.

Deploy ensures your directory is in sync with your development
environment and that it is in a deployable state. If there are any
issues, it will display them and ask if you would like to deploy
anyways.

USAGE
  ggt deploy [DIRECTORY] [--app=<name>] [--prefer=<filesystem>] [--force]

EXAMPLES

  $ ggt deploy
  $ ggt deploy ~/gadget/example
  $ ggt deploy ~/gadget/example --app=example
  $ ggt deploy ~/gadget/example --app=example --prefer=local
  $ ggt deploy ~/gadget/example --app=example --prefer=local --force

ARGUMENTS

  DIRECTORY
    The path to the directory to sync your development environment's
    files to before deploying it to your production environment.
    The directory will be created if it does not exist.

    Defaults to the current working directory. (default: ".")

FLAGS

  -a, --app=<name>
    The Gadget application to deploy.

    If not provided, the application will be inferred from the
    ".gadget/sync.json" file in the chosen directory or any of its
    parent directories.

    If a ".gadget/sync.json" file is not found, you will be
    prompted to choose an application from your list of apps.

  --prefer=<filesystem>
    Which filesystem's changes to automatically keep when
    conflicting changes are detected.

    If not provided, deploy will pause when conflicting changes are
    detected and you will be prompted to choose which changes to
    keep before deploy resumes.

    Must be one of "local" or "gadget".

  --force
    Deploy your development environment to production regardless
    of any issues it may have.

    These issues may include:
      • Syntax errors
      • TypeScript errors
      • Missing fields that should be present on models
```

</details>