### PR TITLE
Retry more

### DIFF
--- a/.changeset/retry-more.md
+++ b/.changeset/retry-more.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Retry `EADDRNOTAVAIL` and `EHOSTUNREACH` errors and retry failed http requests more often.

--- a/src/services/http/http.ts
+++ b/src/services/http/http.ts
@@ -1,4 +1,5 @@
 import { got, type OptionsInit } from "got";
+import ms from "ms";
 import assert from "node:assert";
 import { Agent as HttpAgent } from "node:http";
 import { Agent as HttpsAgent } from "node:https";
@@ -35,6 +36,27 @@ export const http = got.extend({
   agent: {
     http: new HttpAgent({ keepAlive: true }),
     https: new HttpsAgent({ keepAlive: true }),
+  },
+  retry: {
+    limit: 10,
+    methods: ["GET", "PUT", "HEAD", "DELETE", "OPTIONS", "TRACE"],
+    statusCodes: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
+    errorCodes: [
+      "ETIMEDOUT",
+      "ECONNRESET",
+      "EADDRINUSE",
+      "ECONNREFUSED",
+      "EPIPE",
+      "ENOTFOUND",
+      "ENETUNREACH",
+      "EAI_AGAIN",
+      "EADDRNOTAVAIL",
+      "EHOSTUNREACH",
+    ],
+    maxRetryAfter: undefined,
+    calculateDelay: ({ computedValue }) => computedValue,
+    backoffLimit: ms("5s"),
+    noise: 100,
   },
   hooks: {
     beforeRequest: [


### PR DESCRIPTION
I noticed ggt was crashing due to `EADDRNOTAVAIL` and `EHOSTUNREACH` errors while sending http requests. This PR makes those error codes retryable and increases the amount of retry attempts for all http requests.