### PR TITLE
add multi environment support

### DIFF
--- a/spec/__support__/app.ts
+++ b/spec/__support__/app.ts
@@ -5,6 +5,39 @@ import { config } from "../../src/services/config/config.js";
 import { loadCookie } from "../../src/services/http/auth.js";
 
 /**
+ * A test Gadget app to use in tests with multi environment on.
+ */
+export const multiEnvironmentTestApp: App = Object.freeze({
+  id: 1,
+  slug: "test-multi-environment",
+  primaryDomain: "test.gadget.app",
+  hasSplitEnvironments: true,
+  multiEnvironmentEnabled: true,
+  environments: [
+    {
+      id: 1,
+      name: "development",
+      type: "development",
+    },
+    {
+      id: 2,
+      name: "production",
+      type: "production",
+    },
+    {
+      id: 3,
+      name: "cool-environment-development",
+      type: "development",
+    },
+    {
+      id: 4,
+      name: "other-environment-development",
+      type: "development",
+    },
+  ],
+});
+
+/**
  * A test Gadget app to use in tests.
  */
 export const testApp: App = Object.freeze({
@@ -12,6 +45,19 @@ export const testApp: App = Object.freeze({
   slug: "test",
   primaryDomain: "test.gadget.app",
   hasSplitEnvironments: true,
+  multiEnvironmentEnabled: false,
+  environments: [
+    {
+      id: 1,
+      name: "development",
+      type: "development",
+    },
+    {
+      id: 2,
+      name: "production",
+      type: "production",
+    },
+  ],
 });
 
 /**
@@ -24,6 +70,8 @@ export const notTestApp: App = Object.freeze({
   slug: "not-test",
   primaryDomain: "not-test.gadget.app",
   hasSplitEnvironments: false,
+  multiEnvironmentEnabled: false,
+  environments: [],
 });
 
 /**
@@ -38,6 +86,6 @@ export const nockTestApps = ({ optional = true, persist = true } = {}): void => 
       expect(cookie).toBeTruthy();
       return value === cookie;
     })
-    .reply(200, [testApp, notTestApp])
+    .reply(200, [testApp, notTestApp, multiEnvironmentTestApp])
     .persist(persist);
 };

--- a/spec/__support__/filesync.ts
+++ b/spec/__support__/filesync.ts
@@ -206,7 +206,12 @@ export const makeSyncScenario = async ({
     await localDir.loadIgnoreFile();
 
     if (!localFiles[".gadget/sync.json"]) {
-      const syncJson: SyncJson = { app: testApp.slug, filesVersion: "1", mtime: Date.now() + 1 };
+      const syncJson: SyncJson = {
+        app: testApp.slug,
+        filesVersion: "1",
+        currentEnvironment: "development",
+        environments: { development: { filesVersion: "1" } },
+      };
       await fs.outputJSON(localDir.absolute(".gadget/sync.json"), syncJson, { spaces: 2 });
     }
   }
@@ -245,6 +250,7 @@ export const makeSyncScenario = async ({
   };
 
   nockEditResponse({
+    app: ctx.app,
     optional: true,
     persist: true,
     operation: FILE_SYNC_HASHES_QUERY,
@@ -277,6 +283,7 @@ export const makeSyncScenario = async ({
   });
 
   nockEditResponse({
+    app: ctx.app,
     optional: true,
     persist: true,
     operation: FILE_SYNC_COMPARISON_HASHES_QUERY,
@@ -307,6 +314,7 @@ export const makeSyncScenario = async ({
   });
 
   nockEditResponse({
+    app: ctx.app,
     optional: true,
     persist: true,
     operation: FILE_SYNC_FILES_QUERY,
@@ -347,6 +355,7 @@ export const makeSyncScenario = async ({
   });
 
   nockEditResponse({
+    app: ctx.app,
     optional: true,
     persist: true,
     operation: PUBLISH_FILE_SYNC_EVENTS_MUTATION,

--- a/spec/commands/list.spec.ts
+++ b/spec/commands/list.spec.ts
@@ -17,8 +17,15 @@ describe("list", () => {
   it("lists apps", async () => {
     mock(user, "getUserOrLogin", () => ({ id: 1, email: "test@example.com", name: "Jane Doe" }));
     mock(app, "getApps", () => [
-      { id: 1, slug: "app-a", primaryDomain: "app-a.example.com", hasSplitEnvironments: true },
-      { id: 2, slug: "app-b", primaryDomain: "cool-app.com", hasSplitEnvironments: true },
+      {
+        id: 1,
+        slug: "app-a",
+        primaryDomain: "app-a.example.com",
+        hasSplitEnvironments: true,
+        multiEnvironmentEnabled: true,
+        environments: [],
+      },
+      { id: 2, slug: "app-b", primaryDomain: "cool-app.com", hasSplitEnvironments: true, multiEnvironmentEnabled: true, environments: [] },
     ]);
 
     await command(ctx);

--- a/spec/commands/sync.spec.ts
+++ b/spec/commands/sync.spec.ts
@@ -77,7 +77,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"2\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"2\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"2\\"}}}",
           "file.txt": "file v2",
         },
       }
@@ -113,7 +113,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"3\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"3\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"3\\"}}}",
           "file.txt": "file v3",
         },
       }
@@ -153,7 +153,7 @@ describe("sync", () => {
           ".gadget/": "",
           ".gadget/backup/": "",
           ".gadget/backup/file.txt": "file v3",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"4\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"4\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"4\\"}}}",
         },
       }
     `);
@@ -197,7 +197,7 @@ describe("sync", () => {
           ".gadget/": "",
           ".gadget/backup/": "",
           ".gadget/backup/file.txt": "file v3",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"5\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"5\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"5\\"}}}",
           "directory/": "",
         },
       }
@@ -245,7 +245,7 @@ describe("sync", () => {
           ".gadget/backup/": "",
           ".gadget/backup/directory/": "",
           ".gadget/backup/file.txt": "file v3",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"6\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"6\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"6\\"}}}",
         },
       }
     `);
@@ -316,7 +316,7 @@ describe("sync", () => {
           ".gadget/backup/": "",
           ".gadget/backup/directory/": "",
           ".gadget/backup/file.txt": "file v3",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"7\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"7\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"7\\"}}}",
           "file1.txt": "file1.txt",
           "file10.txt": "file10.txt",
           "file2.txt": "file2.txt",
@@ -440,7 +440,7 @@ describe("sync", () => {
           ".gadget/backup/": "",
           ".gadget/backup/directory/": "",
           ".gadget/backup/file.txt": "file v3",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"7\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"7\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"7\\"}}}",
           "file1.txt": "file1.txt",
           "file10.txt": "file10.txt",
           "file2.txt": "file2.txt",
@@ -576,7 +576,7 @@ describe("sync", () => {
           ".gadget/backup/": "",
           ".gadget/backup/directory/": "",
           ".gadget/backup/file.txt": "file v3",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"7\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"7\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"7\\"}}}",
           "file.js": "file v2",
           "file1.txt": "file1.txt",
           "file10.txt": "file10.txt",
@@ -639,7 +639,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"2\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"2\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"2\\"}}}",
           ".ignore": "**/tmp",
         },
       }
@@ -680,7 +680,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"3\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"3\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"3\\"}}}",
           ".ignore": "**/tmp",
         },
       }
@@ -712,7 +712,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"2\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"2\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"2\\"}}}",
           "file.txt": "file v2",
         },
       }
@@ -742,7 +742,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"3\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"3\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"3\\"}}}",
           "file.txt": "file v3",
         },
       }
@@ -776,7 +776,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"4\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"4\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"4\\"}}}",
           "renamed-file.txt": "file v3",
         },
       }
@@ -812,7 +812,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"5\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"5\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"5\\"}}}",
         },
       }
     `);
@@ -852,7 +852,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"6\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"6\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"6\\"}}}",
           "directory/": "",
         },
       }
@@ -897,7 +897,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"7\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"7\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"7\\"}}}",
           "renamed-directory/": "",
         },
       }
@@ -944,7 +944,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"8\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"8\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"8\\"}}}",
         },
       }
     `);
@@ -1020,7 +1020,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"9\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"9\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"9\\"}}}",
           "file1.txt": "file1.txt",
           "file10.txt": "file10.txt",
           "file2.txt": "file2.txt",
@@ -1065,7 +1065,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"2\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"2\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"2\\"}}}",
           "file.txt": "v10",
         },
       }
@@ -1131,7 +1131,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"1\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"1\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"1\\"}}}",
           ".ignore": "**/tmp",
           "tmp/": "",
           "tmp/file1.txt": "file1.txt",
@@ -1176,7 +1176,7 @@ describe("sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"2\\"}",
+          ".gadget/sync.json": "{\\"app\\":\\"test\\",\\"filesVersion\\":\\"2\\",\\"currentEnvironment\\":\\"development\\",\\"environments\\":{\\"development\\":{\\"filesVersion\\":\\"2\\"}}}",
           ".ignore": "# watch it all",
         },
       }

--- a/spec/services/app/arg.spec.ts
+++ b/spec/services/app/arg.spec.ts
@@ -12,6 +12,7 @@ describe("AppArg", () => {
     "https://my-app--development.gadget.app",
     "https://my-app.gadget.app/edit",
     "https://my-app.gadget.app/edit/files/routes/GET.js",
+    "https://my-app.gadget.app/edit/cool-new-environment",
   ])("accepts %s", (value) => {
     expect(AppArg(value, "--app")).toEqual("my-app");
   });

--- a/spec/services/app/edit.spec.ts
+++ b/spec/services/app/edit.spec.ts
@@ -25,6 +25,7 @@ describe("Edit", () => {
     loginTestUser();
     ctx = makeContext();
     ctx.app = testApp;
+    ctx.environment = "development";
   });
 
   it("retries queries when it receives a 500", async () => {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -272,22 +272,32 @@ export const command: Command<SyncArgs> = async (ctx) => {
     },
   ).once("error", (error) => ctx.abort(error));
 
+  const editorLink = `https://${filesync.app.slug}.gadget.app/edit${
+    filesync.app.multiEnvironmentEnabled ? `/${filesync.ctx.environment}` : ""
+  }`;
+  const playgroundLink = `https://${filesync.app.slug}.gadget.app/api/graphql/playground`;
+
+  const endpointsLink = filesync.app.multiEnvironmentEnabled
+    ? `
+      • https://${filesync.app.primaryDomain}
+      • https://${filesync.app.slug}--${filesync.ctx.environment}.gadget.app
+      `
+    : filesync.app.hasSplitEnvironments
+      ? `
+      • https://${filesync.app.primaryDomain}
+      • https://${filesync.app.slug}--development.gadget.app`
+      : `
+      • https://${filesync.app.primaryDomain}`;
+
   ctx.log.printlns`
     ggt v${config.version}
 
     App         ${filesync.app.slug}
-    Editor      https://${filesync.app.primaryDomain}/edit
-    Playground  https://${filesync.app.primaryDomain}/api/graphql/playground
+    Editor      ${editorLink}
+    Playground  ${playgroundLink}
     Docs        https://docs.gadget.dev/api/${filesync.app.slug}
 
-    Endpoints ${
-      filesync.app.hasSplitEnvironments
-        ? `
-      • https://${filesync.app.primaryDomain}
-      • https://${filesync.app.slug}--development.gadget.app`
-        : `
-      • https://${filesync.app.primaryDomain}`
-    }
+    Endpoints ${endpointsLink}
 
     Watching for file changes... {gray Press Ctrl+C to stop}
   `;

--- a/src/services/app/app.ts
+++ b/src/services/app/app.ts
@@ -10,6 +10,14 @@ export const App = z.object({
   slug: z.string(),
   primaryDomain: z.string(),
   hasSplitEnvironments: z.boolean(),
+  multiEnvironmentEnabled: z.boolean(),
+  environments: z.array(
+    z.object({
+      id: z.union([z.string(), z.number(), z.bigint()]),
+      name: z.string(),
+      type: z.string(),
+    }),
+  ),
 });
 
 export type App = z.infer<typeof App>;

--- a/src/services/command/context.ts
+++ b/src/services/command/context.ts
@@ -53,6 +53,7 @@ export class Context<
   #parent?: Context<ArgsDefinition, ParentArgs>;
   #user?: User;
   #app?: App;
+  #environment?: string;
 
   private constructor({
     args,
@@ -107,6 +108,21 @@ export class Context<
     }
 
     this.#log = this.#log.child({ fields: { app } });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  get environment(): string | undefined {
+    return this.#environment ?? this.#parent?.environment;
+  }
+
+  set environment(environment: string) {
+    const formattedEnvironment = environment.toLowerCase();
+    this.#environment = formattedEnvironment;
+    if (this.#parent) {
+      this.#parent.environment = formattedEnvironment;
+    }
+
+    this.#log = this.#log.child({ fields: { environment } });
   }
 
   /**

--- a/src/services/filesync/filesync.ts
+++ b/src/services/filesync/filesync.ts
@@ -187,7 +187,7 @@ export class FileSync {
             environments: z
               .record(z.object({ filesVersion: z.string() }))
               .nullish()
-              .transform((value, _ctx) => value ?? { development: { filesVersion: "0" } }),
+              .transform((value) => value ?? { development: { filesVersion: "0" } }),
           })
           .parse(json);
       })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
     "useDefineForClassFields": true,
 
     /* Completeness */
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
Adds support to ggt for synching to and from multi environments app.

- New `--environment` / `-e` flag for selecting which environment to sync to
- New environment selector for when mutl-environment is enabled on the app you're synching from/to
- I've removed most of the references to `mtime`
- I wanted to possibly update `makeSyncContext` to support multi-environment but I think it'll be worth shipping this quick and coming back around to do it later. In the meantime I've tried adding tests around the edges for this PR.

A new sync command might look like this: `ggt sync --app my-app --environment cool-new-development`

🎩 instructions:

I think there's a bunch of states that should be tophatted:

1. non multi-environment app
2. multi-environment app
3. "legacy" app where split environment is disabled should still work
4. non multi-environment app -> sync -> change/migrate environment to mutli-environment -> sync

just to name a few...