### PR TITLE
Print out file-related fatal errors on `ggt sync`

### DIFF
--- a/.changeset/purple-turtles-design.md
+++ b/.changeset/purple-turtles-design.md
@@ -1,0 +1,5 @@
+---
+"ggt": minor
+---
+
+All fatal errors related to your files will be displayed in the terminal while running the `sync` mode. This allows you to check if any file changes have caused any issues in your app.

--- a/.changeset/show-fatal-errors.md
+++ b/.changeset/show-fatal-errors.md
@@ -1,5 +1,5 @@
 ---
-"ggt": minor
+"ggt": patch
 ---
 
 All fatal errors related to your files will be displayed in the terminal while running the `sync` mode. This allows you to check if any file changes have caused any issues in your app.

--- a/spec/__support__/filesync.ts
+++ b/spec/__support__/filesync.ts
@@ -382,6 +382,7 @@ export const makeSyncScenario = async ({
         data: {
           publishFileSyncEvents: {
             remoteFilesVersion: String(gadgetFilesVersion),
+            problems: [],
           },
         },
       };

--- a/src/__generated__/edit.graphql
+++ b/src/__generated__/edit.graphql
@@ -147,6 +147,13 @@ type LogSearchResult {
   status: String!
 }
 
+type Problem {
+  level: String!
+  message: String!
+  path: String!
+  type: String!
+}
+
 type MigrateAACResult {
   reason: String
   success: Boolean!
@@ -189,6 +196,7 @@ input PublishFileSyncEventsInput {
 
 type PublishFileSyncEventsResult {
   remoteFilesVersion: String!
+  problems: [Problem!]!
 }
 
 type PublishIssue {

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -313,6 +313,14 @@ export type MutationUploadTemplateAssetArgs = {
   file: Scalars['Upload']['input'];
 };
 
+export type Problem = {
+  __typename?: 'Problem';
+  level: Scalars['String']['output'];
+  message: Scalars['String']['output'];
+  path: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+};
+
 export type PublishFileSyncEventsInput = {
   changed: Array<FileSyncChangedEventInput>;
   deleted: Array<FileSyncDeletedEventInput>;
@@ -321,6 +329,7 @@ export type PublishFileSyncEventsInput = {
 
 export type PublishFileSyncEventsResult = {
   __typename?: 'PublishFileSyncEventsResult';
+  problems: Array<Problem>;
   remoteFilesVersion: Scalars['String']['output'];
 };
 
@@ -598,7 +607,7 @@ export type PublishFileSyncEventsMutationVariables = Exact<{
 }>;
 
 
-export type PublishFileSyncEventsMutation = { __typename?: 'Mutation', publishFileSyncEvents: { __typename?: 'PublishFileSyncEventsResult', remoteFilesVersion: string } };
+export type PublishFileSyncEventsMutation = { __typename?: 'Mutation', publishFileSyncEvents: { __typename?: 'PublishFileSyncEventsResult', remoteFilesVersion: string, problems: Array<{ __typename?: 'Problem', level: string, message: string, path: string, type: string }> } };
 
 export type FileSyncFilesQueryVariables = Exact<{
   paths: Array<Scalars['String']['input']> | Scalars['String']['input'];

--- a/src/services/app/edit/operation.ts
+++ b/src/services/app/edit/operation.ts
@@ -103,6 +103,12 @@ export const PUBLISH_FILE_SYNC_EVENTS_MUTATION = sprint(/* GraphQL */ `
   mutation PublishFileSyncEvents($input: PublishFileSyncEventsInput!) {
     publishFileSyncEvents(input: $input) {
       remoteFilesVersion
+      problems {
+        level
+        message
+        path
+        type
+      }
     }
   }
 `) as GraphQLMutation<PublishFileSyncEventsMutation, PublishFileSyncEventsMutationVariables>;

--- a/src/services/filesync/filesync.ts
+++ b/src/services/filesync/filesync.ts
@@ -1,3 +1,4 @@
+import chalk from "chalk";
 import dayjs from "dayjs";
 import { execa } from "execa";
 import { findUp } from "find-up";
@@ -581,7 +582,7 @@ export class FileSync {
     }
 
     const {
-      publishFileSyncEvents: { remoteFilesVersion },
+      publishFileSyncEvents: { remoteFilesVersion, problems },
     } = await this.edit.mutate({
       mutation: PUBLISH_FILE_SYNC_EVENTS_MUTATION,
       variables: {
@@ -618,6 +619,26 @@ export class FileSync {
       // we can't save the remoteFilesVersion because we haven't
       // received the intermediate filesVersions yet
       throw new Error("Files version mismatch");
+    }
+
+    if (problems.length > 0) {
+      const problemGroup: Record<string, string[]> = {};
+      problems.forEach((problem) => {
+        if (!(problem.path in problemGroup)) {
+          problemGroup[problem.path] = [];
+        }
+        problemGroup[problem.path]?.push(problem.message);
+      });
+
+      this.ctx.log.println2(chalk.red("Gadget has detected the following fatal errors with your files:"));
+      Object.entries(problemGroup).forEach(([path, messages]) => {
+        this.ctx.log.println(chalk.red(`[${path}]`));
+        messages.forEach((message) => {
+          this.ctx.log.println(chalk.red(` - ${message}`));
+        });
+      });
+      this.ctx.log.println("");
+      this.ctx.log.println2(chalk.red("Your app will not be operational until all fatal errors are fixed."));
     }
 
     await this._save(remoteFilesVersion);

--- a/src/services/filesync/filesync.ts
+++ b/src/services/filesync/filesync.ts
@@ -1,4 +1,3 @@
-import chalk from "chalk";
 import dayjs from "dayjs";
 import { execa } from "execa";
 import { findUp } from "find-up";
@@ -630,15 +629,15 @@ export class FileSync {
         problemGroup[problem.path]?.push(problem.message);
       });
 
-      this.ctx.log.println2(chalk.red("Gadget has detected the following fatal errors with your files:"));
+      this.ctx.log.println2`{red Gadget has detected the following fatal errors with your files:}`;
       Object.entries(problemGroup).forEach(([path, messages]) => {
-        this.ctx.log.println(chalk.red(`[${path}]`));
+        this.ctx.log.println`{red [${path}]}`;
         messages.forEach((message) => {
-          this.ctx.log.println(chalk.red(` - ${message}`));
+          this.ctx.log.println`{red  - ${message}}`;
         });
       });
       this.ctx.log.println("");
-      this.ctx.log.println2(chalk.red("Your app will not be operational until all fatal errors are fixed."));
+      this.ctx.log.println2`{red Your app will not be operational until all fatal errors are fixed.}`;
     }
 
     await this._save(remoteFilesVersion);


### PR DESCRIPTION
In an upcoming Gadget feature, we will introduce a new error level called `Fatal` that comes from the files and will make the app unable to run.
<img width="631" alt="CleanShot 2024-01-11 at 13 02 42@2x" src="https://github.com/gadget-inc/ggt/assets/34646302/f5bb600c-123a-4f80-a4ec-01fc68e5d707">

This PR is to print out these file-related fatal errors during the `ggt sync` mode to inform the user of issues with the files.

Gadget side for the new GraphQL response value:
https://github.com/gadget-inc/gadget/pull/9652