### PR TITLE
Display primary domain

### DIFF
--- a/.changeset/use-primary-domain.md
+++ b/.changeset/use-primary-domain.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Display the primary domain for the /edit + playground links

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -233,8 +233,8 @@ export const command: Command<SyncArgs> = async (ctx) => {
     ggt v${config.version}
 
     App         ${filesync.app.slug}
-    Editor      https://${filesync.app.slug}.gadget.app/edit
-    Playground  https://${filesync.app.slug}.gadget.app/api/graphql/playground
+    Editor      https://${filesync.app.primaryDomain}/edit
+    Playground  https://${filesync.app.primaryDomain}/api/graphql/playground
     Docs        https://docs.gadget.dev/api/${filesync.app.slug}
 
     Endpoints ${


### PR DESCRIPTION
We need to use the primary domain for the edit and playground links when an app has a custom domain. This is inline with how Gadget proper works.