### PR TITLE
Increase file backup attempts on Windows

### DIFF
--- a/.changeset/retry-backup-more.md
+++ b/.changeset/retry-backup-more.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Retry errors when backing up files on Windows more often.

--- a/src/services/filesync/filesync.ts
+++ b/src/services/filesync/filesync.ts
@@ -657,7 +657,9 @@ export class FileSync {
           }
         },
         {
-          retries: 2,
+          // windows tends to run into these issues way more often than
+          // mac/linux, so we retry more times
+          retries: config.windows ? 4 : 2,
           minTimeout: ms("100ms"),
           onFailedAttempt: (error) => {
             this.ctx.log.warn("failed to move file to backup", { error, currentPath, backupPath });


### PR DESCRIPTION
I'm still seeing ggt crash with `dest already exists` while moving files to `.gadget/backup/`. This crash seems to only be happening on Windows, so this increases how many times we attempt to backup files on Windows.