### PR TITLE
Disallow deploy on `ggt deploy` if there are fatal errors

### DIFF
--- a/.changeset/disallow-deploy-with-fatal-errors.md
+++ b/.changeset/disallow-deploy-with-fatal-errors.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+When you run the `deploy` command, all fatal errors will be displayed in the terminal and exit early if there are fatal errors to prevent the app from being deployed.

--- a/src/services/filesync/error.ts
+++ b/src/services/filesync/error.ts
@@ -66,3 +66,28 @@ export class TooManySyncAttemptsError extends CLIError {
     `;
   }
 }
+
+export class DeployDisallowedError extends CLIError {
+  isBug = IsBug.MAYBE;
+
+  constructor(readonly fatalErrors: Record<string, string[]>) {
+    super("This application is not allowed to be deployed due to fatal errors.");
+  }
+
+  protected render(): string {
+    const errorMessages: string[] = [];
+    for (const [path, messages] of Object.entries(this.fatalErrors)) {
+      errorMessages.push(`[${path}]`);
+      for (const message of messages) {
+        errorMessages.push(` - ${message}`);
+      }
+    }
+
+    return sprint`
+{red Gadget has detected the following fatal errors with your files:
+
+${errorMessages.join("\n")}
+
+Please fix these errors and try again.}`;
+  }
+}

--- a/src/services/util/problems-group.ts
+++ b/src/services/util/problems-group.ts
@@ -1,0 +1,11 @@
+export const groupProblemsByApiIdentifier = (problems: { apiIdentifier: string; message: string }[]): Record<string, string[]> => {
+  const problemGroup: Record<string, string[]> = {};
+  problems.forEach((problem) => {
+    if (!(problem.apiIdentifier in problemGroup)) {
+      problemGroup[problem.apiIdentifier] = [];
+    }
+    problemGroup[problem.apiIdentifier]?.push(problem.message);
+  });
+
+  return problemGroup;
+};


### PR DESCRIPTION
This PR disallows app deployment on `ggt deploy` if fatal errors exist in their app, then show the errors and exits `ggt` early.

<img width="551" alt="CleanShot 2024-01-15 at 11 48 14@2x" src="https://github.com/gadget-inc/ggt/assets/34646302/095f6094-1646-45b7-b740-455112018e05">

Since fatal errors will not make the app operational, we should not allow an app with fatal errors to deploy and break its production app.

Gadget side:
https://github.com/gadget-inc/gadget/pull/9657