### PR TITLE
Handle GGT_FILES_VERSION_MISMATCH

### DIFF
--- a/.changeset/files-version-mismatch-fix.md
+++ b/.changeset/files-version-mismatch-fix.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Handle new `GGT_FILES_VERSION_MISMATCH` error.

--- a/src/services/filesync/filesync.ts
+++ b/src/services/filesync/filesync.ts
@@ -810,7 +810,7 @@ export const isFilesVersionMismatchError = (error: unknown): boolean => {
   if (isGraphQLErrors(error)) {
     error = error[0];
   }
-  return isObject(error) && "message" in error && isString(error.message) && error.message.startsWith("Files version mismatch");
+  return isObject(error) && "message" in error && isString(error.message) && error.message.includes("Files version mismatch");
 };
 
 const swallowFilesVersionMismatch = (ctx: Context, error: unknown): void => {


### PR DESCRIPTION
We shipped a newer files version mismatch error server side that isn't being handled anymore. This makes ggt handle the new error.