### PR TITLE
small QOL changes for ggt deploy multi-environment

### DIFF
--- a/spec/commands/__snapshots__/root.spec.ts.snap
+++ b/spec/commands/__snapshots__/root.spec.ts.snap
@@ -1,23 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`root > when deploy is given > prints the usage when --help is passed 1`] = `
-"Deploy your development environment to production.
+"Deploy a development environment to production.
 
-Deploy ensures your directory is in sync with your development
-environment and that it is in a deployable state. If there are any
+Deploy ensures your directory is in sync with your current 
+development environment and that it is in a deployable state. If there are any
 issues, it will display them and ask if you would like to deploy
 anyways.
 
 USAGE
-  ggt deploy [DIRECTORY] [--app=<name>] [--prefer=<filesystem>] [--force]
+  ggt deploy [DIRECTORY] [--app=<name>] [--environment=<name>] [--prefer=<filesystem>] [--force]
 
 EXAMPLES
 
   $ ggt deploy
   $ ggt deploy ~/gadget/example
   $ ggt deploy ~/gadget/example --app=example
-  $ ggt deploy ~/gadget/example --app=example --prefer=local
-  $ ggt deploy ~/gadget/example --app=example --prefer=local --force
+  $ ggt deploy ~/gadget/example --app=example --environment=development
+  $ ggt deploy ~/gadget/example --app=example --environment=development --prefer=local
+  $ ggt deploy ~/gadget/example --app=example --environment=development --prefer=local --force
 
 ARGUMENTS
 
@@ -39,6 +40,16 @@ FLAGS
 
     If a \\".gadget/sync.json\\" file is not found, you will be
     prompted to choose an application from your list of apps.
+
+  -e, --environment=<name>
+    The environment to deploy from.
+
+    If not provided, the environment will be inferred from the
+    \\".gadget/sync.json\\" file in the chosen directory or any of its
+    parent directories.
+
+    If a \\".gadget/sync.json\\" file is not found, you will be
+    prompted to choose an environment from your list of environments.
 
   --prefer=<filesystem>
     Which filesystem's changes to automatically keep when
@@ -62,7 +73,7 @@ FLAGS
 `;
 
 exports[`root > when deploy is given > prints the usage when -h is passed 1`] = `
-"Deploy your development environment to production.
+"Deploy a development environment to production.
 
 USAGE
   ggt deploy [DIRECTORY]
@@ -74,10 +85,12 @@ EXAMPLES
   $ ggt deploy
   $ ggt deploy ~/gadget/example
   $ ggt deploy ~/gadget/example --app=example
-  $ ggt deploy ~/gadget/example --app=example --prefer=local
+  $ ggt deploy ~/gadget/example --app=example --environment=development
+  $ ggt deploy ~/gadget/example --app=example --environment=development --prefer=local
 
 FLAGS
-  -a, --app=<name>          The Gadget application to deploy
+  -a, --app=<name>           The Gadget application to deploy
+  -e, --environment=<name>   The environment to deploy from
       --prefer=<filesystem>  Prefer \\"local\\" or \\"gadget\\" conflicting changes
       --force                Deploy regardless of any issues found
 

--- a/spec/commands/deploy.spec.ts
+++ b/spec/commands/deploy.spec.ts
@@ -149,7 +149,7 @@ describe("deploy", () => {
 
     expectStdout().toMatchInlineSnapshot(`
       "
-      Deploying test.gadget.app (​https://test.gadget.app/​)
+      Deploying development to test.gadget.app (​https://test.gadget.app/​)
 
       Issues found
 
@@ -200,7 +200,7 @@ describe("deploy", () => {
 
     expectStdout().toMatchInlineSnapshot(`
       "
-      Deploying test.gadget.app (​https://test.gadget.app/​)
+      Deploying development to test.gadget.app (​https://test.gadget.app/​)
 
       Issues found
 
@@ -326,7 +326,7 @@ describe("deploy", () => {
 
     expectStdout().toMatchInlineSnapshot(`
       "
-      Deploying test.gadget.app (​https://test.gadget.app/​)
+      Deploying development to test.gadget.app (​https://test.gadget.app/​)
 
       Issues found
 
@@ -475,7 +475,7 @@ describe("deploy", () => {
 
     expectStdout().toMatchInlineSnapshot(`
       "
-      Deploying test.gadget.app (​https://test.gadget.app/​)
+      Deploying development to test.gadget.app (​https://test.gadget.app/​)
 
       Deploy successful! Check logs (​https://test.gadget.app/url/to/logs/with/traceId​)
       "
@@ -499,7 +499,7 @@ describe("deploy", () => {
 
     expectStdout().toMatchInlineSnapshot(`
       "
-      Deploying test.gadget.app (​https://test.gadget.app/​)
+      Deploying development to test.gadget.app (​https://test.gadget.app/​)
       Production environment limit reached. Upgrade your plan to deploy
       "
     `);
@@ -570,7 +570,7 @@ describe("deploy", () => {
 
     expectStdout().toMatchInlineSnapshot(`
       "
-      Deploying test.gadget.app (​https://test.gadget.app/​)
+      Deploying development to test.gadget.app (​https://test.gadget.app/​)
 
       An error occurred while communicating with Gadget
       "
@@ -647,7 +647,7 @@ describe("deploy", () => {
 
     expectStdout().toMatchInlineSnapshot(`
       "
-      Deploying test.gadget.app (​https://test.gadget.app/​)
+      Deploying development to test.gadget.app (​https://test.gadget.app/​)
 
       GGT_ASSET_BUILD_FAILED: An error occurred while building production assets
 
@@ -711,7 +711,7 @@ describe("deploy", () => {
 
     expectStdout().toMatchInlineSnapshot(`
       "
-      Deploying test.gadget.app (​https://test.gadget.app/​)
+      Deploying development to test.gadget.app (​https://test.gadget.app/​)
 
       Gadget has detected the following fatal errors with your files:
 


### PR DESCRIPTION
- added info/help text about using the `--environment` flag alongside deploy command
- updated status text to show proper environment
- updated deploying text to show which environment you're deploying from

There's a bug with the `status.output` not sending back the correct environment logs, that'll be fixed in a separate PR.

For multi-environment deploy to work properly you'll have to wait for https://github.com/gadget-inc/gadget/pull/9956 to be in main.