### PR TITLE
fixed unknown environment message showing production

### DIFF
--- a/src/services/filesync/filesync.ts
+++ b/src/services/filesync/filesync.ts
@@ -252,7 +252,7 @@ export class FileSync {
       if (!env) {
         const similarEnvironments = sortBySimilar(
           environment,
-          app.environments.map((env) => env.name.toLowerCase()),
+          filteredSelectableEnvironments.map((env) => env.name.toLowerCase()),
         ).slice(0, 5);
 
         throw new ArgError(


### PR DESCRIPTION
ggt sync was showing:

```
Unknown environment:

  production

Did you mean one of these?

  • production
  • development
```

now it'll show:

```
Unknown environment:

  production

Did you mean one of these?

  • development
```

💯 