### PR TITLE
Improve "ggt status" output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,10 @@
           mkcert = pkgs.mkcert;
           nix-direnv = pkgs.nix-direnv.override { enableFlakes = true; };
           nodejs = pkgs.nodejs-16_x;
+
+          dggt = pkgs.writeShellScriptBin "dggt" ''
+            GGT_ENV=production "$WORKSPACE_ROOT"/bin/dev.js "$@"
+          '';
         };
 
         devShell = pkgs.mkShell {

--- a/spec/__support__/mock.ts
+++ b/spec/__support__/mock.ts
@@ -161,6 +161,14 @@ export const mockSideEffects = (): void => {
   vi.mock("node-notifier", () => ({ default: { notify: vi.fn().mockName("notify") } }));
   vi.mock("open", () => ({ default: vi.fn().mockName("open") }));
   vi.mock("which", () => ({ default: { sync: vi.fn().mockName("whichSync").mockReturnValue("/path/to/yarn") } }));
+  vi.mock("simple-git", () => ({
+    simpleGit: vi
+      .fn()
+      .mockName("simpleGit")
+      .mockReturnValue({
+        revparse: vi.fn().mockName("revparse").mockResolvedValue("test-branch"),
+      }),
+  }));
 
   beforeEach(() => {
     // alway opt in to confirm prompts

--- a/spec/commands/__snapshots__/root.spec.ts.snap
+++ b/spec/commands/__snapshots__/root.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`root > when deploy is given > prints the usage when --help is passed 1`
 Your local filesystem must be in sync with your development
 environment before you can deploy.
 
-Changes will be calculated from the last time you ran
+Changes are calculated from the last time you ran
 \\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\" on your local filesystem.
 
 If your environment has also made changes since the last sync,
@@ -79,7 +79,7 @@ exports[`root > when deploy is given > prints the usage when -h is passed 1`] = 
 Your local filesystem must be in sync with your development
 environment before you can deploy.
 
-Changes will be calculated from the last time you ran
+Changes are calculated from the last time you ran
 \\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\" on your local filesystem.
 
 USAGE
@@ -104,7 +104,7 @@ exports[`root > when dev is given > prints the usage when --help is passed 1`] =
 "Sync your local filesystem with your environment's filesystem,
 in real-time.
 
-Changes will be calculated from the last time you ran
+Changes are calculated from the last time you ran
 \\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\" on your local filesystem.
 
 If your environment has also made changes since the last sync,
@@ -201,7 +201,7 @@ exports[`root > when dev is given > prints the usage when -h is passed 1`] = `
 "Sync your local filesystem with your environment's filesystem,
 in real-time.
 
-Changes will be calculated from the last time you ran
+Changes are calculated from the last time you ran
 \\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\" on your local filesystem.
 
 USAGE
@@ -295,7 +295,7 @@ EXAMPLES
 exports[`root > when pull is given > prints the usage when --help is passed 1`] = `
 "Pull changes from your environment's filesystem to your local filesystem.
 
-Changes will be calculated from the last time you ran
+Changes are calculated from the last time you ran
 \\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\" in the chosen directory.
 
 If your local filesystem has also made changes since the last sync,
@@ -353,7 +353,7 @@ Run \\"ggt pull -h\\" for less information.
 exports[`root > when pull is given > prints the usage when -h is passed 1`] = `
 "Pull changes from your environment's filesystem to your local filesystem.
 
-Changes will be calculated from the last time you ran
+Changes are calculated from the last time you ran
 \\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\" on your local filesystem.
 
 USAGE
@@ -377,7 +377,7 @@ FLAGS
 exports[`root > when push is given > prints the usage when --help is passed 1`] = `
 "Push changes from your local filesystem to your environment's filesystem.
 
-Changes will be calculated from the last time you ran
+Changes are calculated from the last time you ran
 \\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\" on your local filesystem.
 
 If your environment has also made changes since the last sync,
@@ -435,7 +435,7 @@ Run \\"ggt push -h\\" for less information.
 exports[`root > when push is given > prints the usage when -h is passed 1`] = `
 "Push changes from your local filesystem to your environment's filesystem.
 
-Changes will be calculated from the last time you ran
+Changes are calculated from the last time you ran
 \\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\" on your local filesystem.
 
 USAGE
@@ -457,11 +457,11 @@ FLAGS
 `;
 
 exports[`root > when status is given > prints the usage when --help is passed 1`] = `
-"Show changes made to your local filesystem and
-your environment's filesystem.
+"Show changes made to your local filesystem and your
+environment's filesystem.
 
-Changes will be calculated from the last time you ran
-\\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\" in the chosen directory.
+Changes are calculated from the last time you ran
+\\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\".
 
 USAGE
 
@@ -474,11 +474,11 @@ EXAMPLES
 `;
 
 exports[`root > when status is given > prints the usage when -h is passed 1`] = `
-"Show changes made to your local filesystem and
-your environment's filesystem.
+"Show changes made to your local filesystem and your
+environment's filesystem.
 
-Changes will be calculated from the last time you ran
-\\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\" in the chosen directory.
+Changes are calculated from the last time you ran
+\\"ggt dev\\", \\"ggt push\\", or \\"ggt pull\\".
 
 USAGE
 

--- a/spec/commands/__snapshots__/status.spec.ts.snap
+++ b/spec/commands/__snapshots__/status.spec.ts.snap
@@ -1,0 +1,49 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`status > prints the expected message when both local and gadget files have changed 1`] = `
+"Application  test
+Environment  development
+ Git Branch  test-branch
+
+Your local filesystem has changed.
++  local-file.txt  created 
+
+Your environment's filesystem has changed.
++  gadget-file.txt  created 
+"
+`;
+
+exports[`status > prints the expected message when gadget files have changed 1`] = `
+"Application  test
+Environment  development
+ Git Branch  test-branch
+
+Your local filesystem has not changed.
+
+Your environment's filesystem has changed.
++  gadget-file.txt  created 
+"
+`;
+
+exports[`status > prints the expected message when local files have changed 1`] = `
+"Application  test
+Environment  development
+ Git Branch  test-branch
+
+Your local filesystem has changed.
++  local-file.txt  created 
+
+Your environment's filesystem has not changed.
+"
+`;
+
+exports[`status > prints the expected message when nothing has changed 1`] = `
+"Application  test
+Environment  development
+ Git Branch  test-branch
+
+Your local filesystem has not changed.
+
+Your environment's filesystem has not changed.
+"
+`;

--- a/spec/commands/status.spec.ts
+++ b/spec/commands/status.spec.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, it } from "vitest";
+import { args, command as status, type StatusArgs } from "../../src/commands/status.js";
+import type { Context } from "../../src/services/command/context.js";
+import { nockTestApps } from "../__support__/app.js";
+import { makeContext } from "../__support__/context.js";
+import { makeSyncScenario } from "../__support__/filesync.js";
+import { expectStdout } from "../__support__/stream.js";
+import { loginTestUser } from "../__support__/user.js";
+
+describe("status", () => {
+  let ctx: Context<StatusArgs>;
+
+  beforeEach(() => {
+    loginTestUser();
+    nockTestApps();
+
+    ctx = makeContext({
+      parse: args,
+      argv: ["status"],
+    });
+  });
+
+  it("prints the expected message when nothing has changed", async () => {
+    await makeSyncScenario({
+      localFiles: {
+        ".gadget/": "",
+      },
+    });
+
+    await status(ctx);
+
+    expectStdout().toMatchSnapshot();
+  });
+
+  it("prints the expected message when local files have changed", async () => {
+    await makeSyncScenario({
+      localFiles: {
+        ".gadget/": "",
+        "local-file.txt": "changed",
+      },
+    });
+
+    await status(ctx);
+
+    expectStdout().toMatchSnapshot();
+  });
+
+  it("prints the expected message when gadget files have changed", async () => {
+    await makeSyncScenario({
+      localFiles: {
+        ".gadget/": "",
+      },
+      gadgetFiles: {
+        "gadget-file.txt": "changed",
+      },
+    });
+
+    await status(ctx);
+
+    expectStdout().toMatchSnapshot();
+  });
+
+  it("prints the expected message when both local and gadget files have changed", async () => {
+    await makeSyncScenario({
+      localFiles: {
+        ".gadget/": "",
+        "local-file.txt": "changed",
+      },
+      gadgetFiles: {
+        "gadget-file.txt": "changed",
+      },
+    });
+
+    await status(ctx);
+
+    expectStdout().toMatchSnapshot();
+  });
+});

--- a/spec/services/filesync/sync-json.spec.ts
+++ b/spec/services/filesync/sync-json.spec.ts
@@ -126,17 +126,7 @@ describe("SyncJson.loadOrInit", () => {
     const error = await expectError(() => SyncJson.loadOrInit(ctx, { directory: localDir }));
 
     expect(error).toBeInstanceOf(ArgError);
-    expect(error.message).toMatchInlineSnapshot(`
-      "Unknown environment:
-
-        production
-
-      Did you mean one of these?
-
-        • development
-        • cool-environment-development
-        • other-environment-development"
-    `);
+    expect(error.message).toMatchInlineSnapshot('"You cannot \\"ggt dev\\" your production environment."');
   });
 
   it(`throws ${ArgError.name} when --env is passed an environment that is not in the list of valid environments for the app`, async () => {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,6 +18,7 @@ export type DeployArgs = typeof args;
 
 export const args = {
   ...PushArgs,
+  "--env": { type: String, alias: ["-e", "--from", "--environment"] },
   "--allow-problems": { type: Boolean, alias: "--allow-issues" },
 };
 
@@ -29,7 +30,7 @@ export const usage: Usage = (ctx) => {
       Your local filesystem must be in sync with your development
       environment before you can deploy.
 
-      Changes will be calculated from the last time you ran
+      Changes are calculated from the last time you ran
       "ggt dev", "ggt push", or "ggt pull" on your local filesystem.
 
       {bold USAGE}
@@ -56,7 +57,7 @@ export const usage: Usage = (ctx) => {
     Your local filesystem must be in sync with your development
     environment before you can deploy.
 
-    Changes will be calculated from the last time you ran
+    Changes are calculated from the last time you ran
     "ggt dev", "ggt push", or "ggt pull" on your local filesystem.
 
     If your environment has also made changes since the last sync,

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -41,7 +41,7 @@ export const usage: Usage = (ctx) => {
       Sync your local filesystem with your environment's filesystem,
       in real-time.
 
-      Changes will be calculated from the last time you ran
+      Changes are calculated from the last time you ran
       "ggt dev", "ggt push", or "ggt pull" on your local filesystem.
 
       {bold USAGE}
@@ -70,7 +70,7 @@ export const usage: Usage = (ctx) => {
     Sync your local filesystem with your environment's filesystem,
     in real-time.
 
-    Changes will be calculated from the last time you ran
+    Changes are calculated from the last time you ran
     "ggt dev", "ggt push", or "ggt pull" on your local filesystem.
 
     If your environment has also made changes since the last sync,
@@ -355,18 +355,19 @@ export const command: Command<DevArgs> = async (ctx) => {
     },
   ).once("error", (error) => ctx.abort(error));
 
-  ctx.log.println`
-ggt v${config.version}
+  const buffer = ctx.log.buffer();
+  buffer.println2`ggt v${config.version}`;
+  buffer.println(await syncJson.sprintState());
+  buffer.println`
+    ------------------------
+    Preview      https://${syncJson.app.slug}--${syncJson.env.name}.gadget.app
+    Editor       https://${syncJson.app.primaryDomain}/edit/${syncJson.env.name}
+    Playground   https://${syncJson.app.primaryDomain}/api/playground/graphql?environment=${syncJson.env.name}
+    Docs         https://docs.gadget.dev/api/${syncJson.app.slug}
 
-${await syncJson.sprintState()}
-------------------------
-Preview      https://${syncJson.app.slug}--${syncJson.env.name}.gadget.app
-Editor       https://${syncJson.app.primaryDomain}/edit/${syncJson.env.name}
-Playground   https://${syncJson.app.primaryDomain}/api/playground/graphql?environment=${syncJson.env.name}
-Docs         https://docs.gadget.dev/api/${syncJson.app.slug}
-
-Watching for file changes... {gray Press Ctrl+C to stop}
+    Watching for file changes... {gray Press Ctrl+C to stop}
   `;
+  buffer.flush();
 
   ctx.onAbort(async (reason) => {
     ctx.log.info("stopping", { reason });

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -17,7 +17,7 @@ export const usage: Usage = (ctx) => {
     return sprint`
       Pull changes from your environment's filesystem to your local filesystem.
 
-      Changes will be calculated from the last time you ran
+      Changes are calculated from the last time you ran
       "ggt dev", "ggt push", or "ggt pull" on your local filesystem.
 
       {bold USAGE}
@@ -41,7 +41,7 @@ export const usage: Usage = (ctx) => {
   return sprint`
     Pull changes from your environment's filesystem to your local filesystem.
 
-    Changes will be calculated from the last time you ran
+    Changes are calculated from the last time you ran
     "ggt dev", "ggt push", or "ggt pull" in the chosen directory.
 
     If your local filesystem has also made changes since the last sync,

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -17,7 +17,7 @@ export const usage: Usage = (ctx) => {
     return sprint`
       Push changes from your local filesystem to your environment's filesystem.
 
-      Changes will be calculated from the last time you ran
+      Changes are calculated from the last time you ran
       "ggt dev", "ggt push", or "ggt pull" on your local filesystem.
 
       {bold USAGE}
@@ -41,7 +41,7 @@ export const usage: Usage = (ctx) => {
   return sprint`
     Push changes from your local filesystem to your environment's filesystem.
 
-    Changes will be calculated from the last time you ran
+    Changes are calculated from the last time you ran
     "ggt dev", "ggt push", or "ggt pull" on your local filesystem.
 
     If your environment has also made changes since the last sync,

--- a/src/services/output/log/logger.ts
+++ b/src/services/output/log/logger.ts
@@ -1,10 +1,25 @@
 import { unthunk } from "../../util/function.js";
+import { sprint, sprintTable, sprintln, sprintln2, sprintlns, sprintlns2 } from "../sprint.js";
+import { stdout } from "../stream.js";
 import { createPrinter, type Printer } from "./printer.js";
 import { createStructuredLogger, type StructuredLogger, type StructuredLoggerOptions } from "./structured.js";
 
 export type Logger = StructuredLogger &
   Printer & {
+    /**
+     * Creates a child logger with the given options. The child logger
+     * inherits the name and fields of the parent logger.
+     *
+     * @param options
+     */
     child(options: Partial<StructuredLoggerOptions>): Logger;
+
+    /**
+     * Creates a buffer that can be used to batch multiple print
+     * statements together. Call `flush` to print all the buffered
+     * messages to stdout in a single write.
+     */
+    buffer(): Printer & { flush(): void };
   };
 
 /**
@@ -39,12 +54,30 @@ export const createLogger = ({ name, fields: loggerFields, devFields: loggerDevF
   return {
     ...createPrinter({ name }),
     ...createStructuredLogger({ name, fields: loggerFields, devFields: loggerDevFields }),
+
     child: ({ name: childName, fields: childFields, devFields: childDevFields }) => {
       return createLogger({
         name: childName || name,
         fields: () => ({ ...unthunk(loggerFields), ...unthunk(childFields) }),
         devFields: { ...unthunk(loggerDevFields), ...unthunk(childDevFields) },
       });
+    },
+
+    buffer: () => {
+      let buf: string[] = [];
+
+      return {
+        print: (...args) => buf.push(sprint(...args)),
+        println: (...args) => buf.push(sprintln(...args)),
+        println2: (...args) => buf.push(sprintln2(...args)),
+        printlns: (...args) => buf.push(sprintlns(...args)),
+        printlns2: (...args) => buf.push(sprintlns2(...args)),
+        printTable: (options) => buf.push(sprintTable(options)),
+        flush() {
+          stdout.write(buf.join(""));
+          buf = [];
+        },
+      };
     },
   };
 };

--- a/src/services/output/log/printer.ts
+++ b/src/services/output/log/printer.ts
@@ -1,9 +1,5 @@
-import type { Options as BoxenOptions } from "boxen";
-import boxen from "boxen";
-import CliTable3 from "cli-table3";
-import { dedent } from "ts-dedent";
 import { config } from "../../config/config.js";
-import { sprint, sprintln, sprintln2, sprintlns, sprintlns2, type Sprint } from "../sprint.js";
+import { sprint, sprintTable, sprintln, sprintln2, sprintlns, sprintlns2, type Sprint, type SprintTableOptions } from "../sprint.js";
 import { stdout } from "../stream.js";
 import { formatters } from "./format/format.js";
 import { Level } from "./level.js";
@@ -63,65 +59,7 @@ export type Printer = {
   /**
    * Prints a table to stdout.
    */
-  printTable: (options: PrintTableOptions) => void;
-};
-
-export type PrintTableOptions = {
-  /**
-   * The message to print above the table.
-   */
-  message?: string;
-
-  /**
-   * The headers of the table.
-   */
-  headers?: string[];
-
-  /**
-   * The rows of the table.
-   */
-  rows: string[][];
-
-  /**
-   * The message to print below the table.
-   */
-  footer?: string;
-
-  /**
-   * The type of borders to use.
-   *
-   * @default "none"
-   */
-  borders?: "none" | "thin" | "thick";
-
-  /**
-   * The amount of empty lines to print between the message, table,
-   * and footer.
-   *
-   * @default 0
-   */
-  spaceY?: number;
-
-  /**
-   * The alignment of the content in each column.
-   *
-   * @default [] (left-aligned)
-   */
-  colAligns?: ("left" | "center" | "right")[];
-
-  /**
-   * The width of each column.
-   *
-   * @default [] (auto-sized)
-   */
-  colWidths?: number[];
-
-  /**
-   * The options to pass to `boxen`.
-   *
-   * @default undefined (no box)
-   */
-  boxen?: BoxenOptions;
+  printTable: (options: SprintTableOptions) => void;
 };
 
 export const createPrinter = ({ name }: { name: string }): Printer => {
@@ -141,77 +79,19 @@ export const createPrinter = ({ name }: { name: string }): Printer => {
     println2: createPrint(sprintln2),
     printlns: createPrint(sprintlns),
     printlns2: createPrint(sprintlns2),
-    printTable({
-      message,
-      headers,
-      rows,
-      footer,
-      borders: borderType = "none",
-      spaceY = 0,
-      colAligns = [],
-      colWidths = [],
-      boxen: boxenOptions,
-    }) {
+    printTable(opts) {
       if (config.logFormat === "json") {
-        stdout.write(formatters.json(Level.PRINT, name, message || boxenOptions?.title || "table", { headers, rows, footer }));
+        stdout.write(
+          formatters.json(Level.PRINT, name, opts.message || opts.boxen?.title || "table", {
+            headers: opts.headers,
+            rows: opts.rows,
+            footer: opts.footer,
+          }),
+        );
         return;
       }
 
-      const table = new CliTable3({
-        chars: borders[borderType],
-        colAligns,
-        colWidths,
-        head: headers,
-        style: { head: [], border: [] },
-      });
-
-      table.push(...rows);
-
-      const padding = "\n".repeat(spaceY + 1);
-
-      let output = "";
-      if (message) {
-        output += message + padding;
-      }
-
-      if (borderType === "none") {
-        // remove the left padding
-        output += dedent(table.toString()).slice(1);
-      } else {
-        output += table.toString();
-      }
-
-      if (footer) {
-        output += padding + footer;
-      }
-
-      if (boxenOptions) {
-        output = boxen(output, boxenOptions);
-      }
-
-      this.println2(output);
+      this.println2(sprintTable(opts));
     },
   };
-};
-
-// prettier-ignore
-const borders = {
-  none: {
-       "top-left": "",    top: "",    "top-mid": "",    "top-right": "",
-       "left-mid": "",    mid: "",    "mid-mid": "",    "right-mid": "",
-             left: "",                   middle: "",          right: "",
-    "bottom-left": "", bottom: "", "bottom-mid": "", "bottom-right": "",
-  },
-  thin: {
-       "top-left": "┌",    top: "─",    "top-mid": "┬",    "top-right": "┐",
-       "left-mid": "├",    mid: "─",    "mid-mid": "┼",    "right-mid": "┤",
-             left: "│",                    middle: "│",          right: "│",
-    "bottom-left": "└", bottom: "─", "bottom-mid": "┴", "bottom-right": "┘",
-  },
-  thick: {
-       "top-left": "╔",    top: "═",    "top-mid": "╤",    "top-right": "╗",
-             left: "║",                    middle: "│",          right: "║",
-       "left-mid": "╟",    mid: "─",    "mid-mid": "┼",    "right-mid": "╢",
-    "bottom-left": "╚", bottom: "═", "bottom-mid": "╧", "bottom-right": "╝",
-  },
 };

--- a/src/services/output/sprint.ts
+++ b/src/services/output/sprint.ts
@@ -1,4 +1,7 @@
+import type { Options as BoxenOptions } from "boxen";
+import boxen from "boxen";
 import chalkTemplate from "chalk-template";
+import CliTable3 from "cli-table3";
 import { dedent } from "ts-dedent";
 import { isString } from "../util/is.js";
 
@@ -26,4 +29,130 @@ export const sprintlns: Sprint = (template, ...values) => {
 
 export const sprintlns2: Sprint = (template, ...values) => {
   return sprintlns(template, ...values) + "\n";
+};
+
+export const sprintTable = ({
+  message,
+  headers,
+  rows,
+  footer,
+  borders: borderType = "none",
+  spaceY = 0,
+  colAligns = [],
+  colWidths = [],
+  boxen: boxenOptions,
+}: SprintTableOptions): string => {
+  const table = new CliTable3({
+    chars: borders[borderType],
+    colAligns,
+    colWidths,
+    head: headers,
+    style: { head: [], border: [] },
+  });
+
+  table.push(...rows);
+
+  const padding = "\n".repeat(spaceY + 1);
+
+  let output = "";
+  if (message) {
+    output += message + padding;
+  }
+
+  if (borderType === "none") {
+    // remove the left padding
+    output += dedent(table.toString()).slice(1);
+  } else {
+    output += table.toString();
+  }
+
+  if (footer) {
+    output += padding + footer;
+  }
+
+  if (boxenOptions) {
+    output = boxen(output, boxenOptions);
+  }
+
+  return output;
+};
+
+// prettier-ignore
+const borders = {
+  none: {
+       "top-left": "",    top: "",    "top-mid": "",    "top-right": "",
+       "left-mid": "",    mid: "",    "mid-mid": "",    "right-mid": "",
+             left: "",                   middle: "",          right: "",
+    "bottom-left": "", bottom: "", "bottom-mid": "", "bottom-right": "",
+  },
+  thin: {
+       "top-left": "┌",    top: "─",    "top-mid": "┬",    "top-right": "┐",
+       "left-mid": "├",    mid: "─",    "mid-mid": "┼",    "right-mid": "┤",
+             left: "│",                    middle: "│",          right: "│",
+    "bottom-left": "└", bottom: "─", "bottom-mid": "┴", "bottom-right": "┘",
+  },
+  thick: {
+       "top-left": "╔",    top: "═",    "top-mid": "╤",    "top-right": "╗",
+             left: "║",                    middle: "│",          right: "║",
+       "left-mid": "╟",    mid: "─",    "mid-mid": "┼",    "right-mid": "╢",
+    "bottom-left": "╚", bottom: "═", "bottom-mid": "╧", "bottom-right": "╝",
+  },
+};
+
+export type SprintTableOptions = {
+  /**
+   * The message to print above the table.
+   */
+  message?: string;
+
+  /**
+   * The headers of the table.
+   */
+  headers?: string[];
+
+  /**
+   * The rows of the table.
+   */
+  rows: string[][];
+
+  /**
+   * The message to print below the table.
+   */
+  footer?: string;
+
+  /**
+   * The type of borders to use.
+   *
+   * @default "none"
+   */
+  borders?: "none" | "thin" | "thick";
+
+  /**
+   * The amount of empty lines to print between the message, table,
+   * and footer.
+   *
+   * @default 0
+   */
+  spaceY?: number;
+
+  /**
+   * The alignment of the content in each column.
+   *
+   * @default [] (left-aligned)
+   */
+  colAligns?: ("left" | "center" | "right")[];
+
+  /**
+   * The width of each column.
+   *
+   * @default [] (auto-sized)
+   */
+  colWidths?: number[];
+
+  /**
+   * The options to pass to `boxen`.
+   *
+   * @default undefined (no box)
+   */
+  boxen?: BoxenOptions;
 };


### PR DESCRIPTION
This improves the output of "ggt status" and a few other scenarios.

The biggest change in here is the ability to buffer `println` calls. This makes it easier to format a large message by using multiple `print` calls, and still have the entire message logged as a single statement. This isn't very useful today, but will be in the future when we allow callers to specify what should be printed when `--json` is passed vs when it's not.