### PR TITLE
Handle file backups

### DIFF
--- a/.changeset/handle-file-backups.md
+++ b/.changeset/handle-file-backups.md
@@ -1,0 +1,11 @@
+---
+"ggt": patch
+---
+
+Handle existing files in the `.gadget/backup/` directory.
+
+When `ggt` needs to backup a file that already exists in the `.gadget/backup/` directory, it will now remove the existing file before creating the backup. This should prevent the following error from occurring:
+
+```
+Error: ENOTDIR: not a directory, lstat '.gadget/backup/routes/webhooks/POST-github.js'
+```

--- a/src/services/util/is.ts
+++ b/src/services/util/is.ts
@@ -71,6 +71,22 @@ export const isAbortError = (error: unknown): error is Error | Event => {
   return (error instanceof Error && error.name === "AbortError") || (error instanceof Event && error.type === "abort");
 };
 
+export const isENOENTError = (error: unknown): error is { code: "ENOENT" } => {
+  return isObject(error) && "code" in error && error.code === "ENOENT";
+};
+
+export const isENOTEMPTYError = (error: unknown): error is { code: "ENOTEMPTY" } => {
+  return isObject(error) && "code" in error && error.code === "ENOTEMPTY";
+};
+
+export const isENOTDIRError = (error: unknown): error is { code: "ENOTDIR" } => {
+  return isObject(error) && "code" in error && error.code === "ENOTDIR";
+};
+
+export const isEEXISTError = (error: unknown): error is { code: "EEXIST" } => {
+  return isObject(error) && "code" in error && error.code === "EEXIST";
+};
+
 export const isJavaScriptFile = (filepath: string): boolean => {
   return [".js", ".jsx", ".cjs", ".mjs"].some((ext) => filepath.endsWith(ext));
 };


### PR DESCRIPTION
We've seen errors like this for a while now.

```
Error: ENOTDIR: not a directory, lstat '.gadget/backup/routes/webhooks/POST-github.js'
```

I could never figure out what caused this because I made ggt `rm -rf` the existing backup file (if it exists) in #926.

---

However, I **finally** figured out the scenario that causes this issue:

1. Have `ggt dev` running in the background
2. Create a file in the editor that looks like a directory, e.g. `routes/webhooks`
3. Delete the file in the editor, causing ggt to move it to `.gadget/backup/routes/webhooks`
4. Create a nested file in the editor, e.g. `routes/webhooks/POST-github.js`
5. Delete the nested file in the editor, causing ggt to move it to `.gadget/backup/routes/webhooks/POST-github.js`

The issue happens here because `.gadget/backup/routes/webhooks` already exists and isn't a directory, so the OS can't create the directory needed for `.gadget/backup/routes/webhooks/POST-github.js`.

This PR fixes this issue by detecting `ENOTDIR` errors (or `EEXISTS` on windows) and removing any non-directory parents before trying to create the backup file again.