### PR TITLE
update usages to match new CLI design system

### DIFF
--- a/spec/commands/__snapshots__/root.spec.ts.snap
+++ b/spec/commands/__snapshots__/root.spec.ts.snap
@@ -1,607 +1,429 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`root > when deploy is given > prints the usage when --help is passed 1`] = `
-"Deploy an environment to production.
+"Deploys your app to production.
 
-Your local files must match your environment's files
-before you can deploy. Changes are tracked from
-the last "ggt dev", "ggt push", or "ggt pull" run locally.
+This command first performs a sync to ensure that your local and environment directories
+match, changes are tracked since last sync. If any conflicts are detected, they must be
+resolved before deployment.
 
-If your local files don't match your environment's files, you will
-be prompted to push your local files before you can deploy.
+Usage
+      $ ggt deploy [options]
 
-If your environment has un-pulled changes, and "--force" is not
-passed, you will be prompted to discard them or abort the deploy.
+Options
+      -a, --app <app_name>           Selects a specific app to deploy. Default set on ".gadget/sync.json"
+      --from, -e, --env <env_name>   Selects a specific environment to sync and deploy from. Default set on ".gadget/sync.json"
+      --force                        Deploys by discarding any changes made to the environment directory since last sync
+      --allow-different-directory    Deploys from any local directory with existing files, even if the ".gadget/sync.json" file is missing
+      --allow-different-app          Deploys a different app using the --app command, instead of the one specified in the “.gadget/sync.json” file
+      --allow-problems               Deploys despite any existing issues found in the app (gelly errors, typescript errors etc.)
+      --allow-charges                Deploys even if it results in additional charges to your plan
 
-USAGE
-
-  ggt deploy [--app=<name>] [--from=<env>] [--force]
-             [--allow-problems] [--allow-charges]
-
-EXAMPLES
-
-  $ ggt deploy
-  $ ggt deploy --from=staging
-  $ ggt deploy --from=staging --force
-  $ ggt deploy --from=staging --force --allow-problems
-  $ ggt deploy --from=staging --force --allow-problems --allow-charges
-
-FLAGS
-
-  -a, --app, --application=<name>
-    The application to deploy.
-
-    Defaults to the application within the ".gadget/sync.json"
-    file in the current directory or any parent directories.
-
-  -e, --env, --environment, --from=<name>
-    The environment to deploy from.
-
-    Defaults to the environment within the ".gadget/sync.json"
-    file in the current directory or any parent directories.
-
-  -f, --force
-    Discard any changes made to your environment's filesystem
-    since the last "ggt dev", "ggt push", or "ggt pull".
-
-    Defaults to false.
-
-  --allow-problems, --allow-issues
-    Deploy your environment to production regardless of any problems
-    it may have.
-
-    These problems may include:
-      • Gelly syntax errors
-      • TypeScript errors
-      • Models with missing fields
-
-    Defaults to false.
-
-  --allow-charges
-    Allows "ggt deploy" to continue when deploying your environment
-    to production will add charges to your account.
-
-    Defaults to false.
-
-  --allow-unknown-directory
-    Allows "ggt deploy" to continue when the current directory, nor
-    any parent directories, contain a ".gadget/sync.json" file
-    within it.
-
-    Defaults to false.
-
-  --allow-different-app
-    Allows "ggt deploy" to continue with a different "--app" than the
-    one found within the ".gadget/sync.json" file.
-
-    Defaults to false.
-
-Run "ggt deploy -h" for less information.
+Examples
+      Deploys code from the staging environment of a myBlog
+      $ ggt deploy -a myBlog -from staging 
 "
 `;
 
 exports[`root > when deploy is given > prints the usage when -h is passed 1`] = `
-"Deploy an environment to production.
+"Deploys your app to production.
 
-Your local files must match your environment's files
-before you can deploy. Changes are tracked from
-the last "ggt dev", "ggt push", or "ggt pull" run locally.
+This command first performs a sync to ensure that your local and environment directories
+match, changes are tracked since last sync. If any conflicts are detected, they must be
+resolved before deployment.
 
-USAGE
-  ggt deploy
+Usage
+      $ ggt deploy [options]
 
-EXAMPLES
-  $ ggt deploy
-  $ ggt deploy --from=staging
-  $ ggt deploy --from=staging --force
-  $ ggt deploy --from=staging --force --allow-problems
+Options
+      -a, --app <app_name>           Selects a specific app to deploy. Default set on ".gadget/sync.json"
+      --from, -e, --env <env_name>   Selects a specific environment to sync and deploy from. Default set on ".gadget/sync.json"
+      --force                        Deploys by discarding any changes made to the environment directory since last sync
+      --allow-different-directory    Deploys from any local directory with existing files, even if the ".gadget/sync.json" file is missing
+      --allow-different-app          Deploys a different app using the --app command, instead of the one specified in the “.gadget/sync.json” file
+      --allow-problems               Deploys despite any existing issues found in the app (gelly errors, typescript errors etc.)
+      --allow-charges                Deploys even if it results in additional charges to your plan
 
-FLAGS
-  -a, --app=<name>      The application to deploy
-  -e, --from=<env>      The environment to deploy from
-      --force           Discard changes to your environment's filesystem
-      --allow-problems  Deploy regardless of any problems the environment has
-      --allow-charges   Deploy even if doing so will add charges to your account
-
-Run "ggt deploy --help" for more information.
+Examples
+      Deploys code from the staging environment of a myBlog
+      $ ggt deploy -a myBlog -from staging 
 "
 `;
 
 exports[`root > when dev is given > prints the usage when --help is passed 1`] = `
-"Develop your app by synchronizing your local files with your
-environment's files, in real-time. Changes are tracked from
-the last "ggt dev", "ggt push", or "ggt pull" run locally.
+"Clones your Gadget environment's files to your local machine and keeps it in sync, in order to
+enable local development with your text editor and source code with Git.
 
-While "ggt dev" is running, changes on your local filesystem are
-immediately pushed to your environment, while file changes on
-your environment are immediately pulled to your local filesystem.
+If your app's local directory already exists, this command first performs a sync to ensure
+that your local and environment directories match, changes are tracked since last sync. If any 
+conflicts are detected, they must be resolved before development starts.
 
-If conflicting changes are detected, and "--prefer" is not passed,
-you will be prompted to choose which changes to keep before
-"ggt dev" resumes.
+Usage
+      $ ggt dev [DIRECTORY] [options]
 
-"ggt dev" looks for an ".ignore" file to exclude files and
-directories from being pushed or pulled. The format is identical
-to Git's.
+      DIRECTORY: The directory to sync files to (default: the current directory)
 
-The following files and directories are always ignored:
-  • .DS_Store
-  • .gadget
-  • .git
-  • node_modules
+Options
+      -a, --app <app_name>        Selects the app to sync files with. Default set on ".gadget/sync.json"
+      -e, --env <env_name>        Selects the environment to sync files with. Default set on ".gadget/sync.json"
+      --prefer <source>           Auto-select changes from 'local' or 'environment' source on conflict
+      --allow-unknown-directory   Syncs to any local directory with existing files, even if the ".gadget/sync.json" file is missing
+      --allow-different-app       Syncs with a different app using the --app command, instead of the one specified in the .gadget/sync.json file
 
-Note:
-  • "ggt dev" only works with development environments
-  • "ggt dev" only supports "yarn" v1 for installing dependencies
-  • Avoid deleting or moving all of your files while "ggt dev" is running
+Ignoring files
+      ggt dev uses a .ignore file, similar to .gitignore, to exclude specific files and 
+      folders from syncing. These files are always ignored:
 
-USAGE
+      • .DS_Store
+      • .gadget
+      • .git
+      • node_modules
 
-  ggt dev [DIRECTORY] [--app=<name>] [--env=<name>] [--prefer=<filesystem>]
-                      [--allow-unknown-directory] [--allow-different-app]
+Notes
+      • "ggt dev" only works with development environments
+      • "ggt dev" only supports "yarn" v1 for installing dependencies
+      • Avoid deleting or moving all of your files while "ggt dev" is running
 
-EXAMPLES
+Examples
+      sync an app in a custom path 
+      $ ggt dev ~/myGadgetApps/myBlog --app myBlogApp
+      
+      sync with a specific environment and preselect all local changes on conflicts
+      $ ggt dev --env main --prefer local
 
-  $ ggt dev
-  $ ggt dev ~/gadget/example
-  $ ggt dev ~/gadget/example
-  $ ggt dev ~/gadget/example --app=example
-  $ ggt dev ~/gadget/example --app=example --env=development --prefer=local
-
-ARGUMENTS
-
-  DIRECTORY
-    The path to the directory to synchronize files to.
-    The directory will be created if it does not exist.
-
-    Defaults to the current working directory. (default: ".")
-
-FLAGS
-
-  -a, --app, --application=<name>
-    The application to synchronize files with.
-
-    Defaults to the application within the ".gadget/sync.json"
-    file in the chosen directory or any parent directories.
-
-  -e, --env, --environment=<name>
-    The development environment to synchronize files with.
-
-    Defaults to the environment within the ".gadget/sync.json"
-    file in the chosen directory or any parent directories.
-
-  --prefer=<filesystem>
-    Which filesystem's changes to automatically keep when
-    conflicting changes are detected.
-
-    Must be one of "local" or "environment".
-
-    If not provided, "ggt dev" will pause when conflicting changes
-    are detected and you will be prompted to choose which changes to
-    keep before "ggt dev" resumes.
-
-  --allow-unknown-directory
-    Allows "ggt dev" to continue when the chosen directory, nor
-    any parent directories, contain a ".gadget/sync.json" file
-    within it.
-
-    Defaults to false.
-
-  --allow-different-app
-    Allows "ggt dev" to continue with a different "--app" than the
-    one found within the ".gadget/sync.json" file.
-
-    Defaults to false.
-
-Run "ggt dev -h" for less information.
+      sync a custom path with a specific app, environment and preselect all changes from local on conflicts
+      $ ggt dev ~/gadget/example --app=example --env=development --prefer=local
 "
 `;
 
 exports[`root > when dev is given > prints the usage when -h is passed 1`] = `
-"Develop your app by synchronizing your local files with your
-environment's files, in real-time. Changes are tracked from
-the last "ggt dev", "ggt push", or "ggt pull" run locally.
+"Clones your Gadget environment's files to your local machine and keeps it in sync, in order to
+enable local development with your text editor and source code with Git.
 
-USAGE
-  ggt dev [DIRECTORY]
+If your app's local directory already exists, this command first performs a sync to ensure
+that your local and environment directories match, changes are tracked since last sync. If any 
+conflicts are detected, they must be resolved before development starts.
 
-EXAMPLES
-  $ ggt dev
-  $ ggt dev ~/gadget/example
-  $ ggt dev ~/gadget/example
-  $ ggt dev ~/gadget/example --app=example
-  $ ggt dev ~/gadget/example --app=example --env=development --prefer=local
+Usage
+      $ ggt dev [DIRECTORY] [options]
 
-ARGUMENTS
-  DIRECTORY    The directory to synchronize files to (default: ".")
+      DIRECTORY: The directory to sync files to (default: the current directory)
 
-FLAGS
-  -a, --app=<name>           The application to synchronize files with
-  -e, --env=<name>           The environment to synchronize files with
-      --prefer=<filesystem>  Prefer "local" or "environment" conflicting changes
+Options
+      -a, --app <app_name>        Selects the app to sync files with. Default set on ".gadget/sync.json"
+      -e, --env <env_name>        Selects the environment to sync files with. Default set on ".gadget/sync.json"
+      --prefer <source>           Auto-select changes from 'local' or 'environment' source on conflict
+      --allow-unknown-directory   Syncs to any local directory with existing files, even if the ".gadget/sync.json" file is missing
+      --allow-different-app       Syncs with a different app using the --app command, instead of the one specified in the .gadget/sync.json file
 
-  Run "ggt dev --help" for more information.
+Ignoring files
+      ggt dev uses a .ignore file, similar to .gitignore, to exclude specific files and 
+      folders from syncing. These files are always ignored:
+
+      • .DS_Store
+      • .gadget
+      • .git
+      • node_modules
+
+Notes
+      • "ggt dev" only works with development environments
+      • "ggt dev" only supports "yarn" v1 for installing dependencies
+      • Avoid deleting or moving all of your files while "ggt dev" is running
+
+Examples
+      sync an app in a custom path 
+      $ ggt dev ~/myGadgetApps/myBlog --app myBlogApp
+      
+      sync with a specific environment and preselect all local changes on conflicts
+      $ ggt dev --env main --prefer local
+
+      sync a custom path with a specific app, environment and preselect all changes from local on conflicts
+      $ ggt dev ~/gadget/example --app=example --env=development --prefer=local
 "
 `;
 
 exports[`root > when list is given > prints the usage when --help is passed 1`] = `
-"List your available applications.
+"List the apps available to the currently logged-in user.
 
-USAGE
-  ggt list
-
-EXAMPLES
-  $ ggt list
+Usage
+      ggt list
 "
 `;
 
 exports[`root > when list is given > prints the usage when -h is passed 1`] = `
-"List your available applications.
+"List the apps available to the currently logged-in user.
 
-USAGE
-  ggt list
-
-EXAMPLES
-  $ ggt list
+Usage
+      ggt list
 "
 `;
 
 exports[`root > when login is given > prints the usage when --help is passed 1`] = `
 "Log in to your account.
 
-USAGE
-  ggt login
-
-EXAMPLES
-  $ ggt login
+Usage
+      ggt login
 "
 `;
 
 exports[`root > when login is given > prints the usage when -h is passed 1`] = `
 "Log in to your account.
 
-USAGE
-  ggt login
-
-EXAMPLES
-  $ ggt login
+Usage
+      ggt login
 "
 `;
 
 exports[`root > when logout is given > prints the usage when --help is passed 1`] = `
 "Log out of your account.
 
-USAGE
-  ggt logout
-
-EXAMPLES
-  $ ggt logout
+Usage
+      ggt logout
 "
 `;
 
 exports[`root > when logout is given > prints the usage when -h is passed 1`] = `
 "Log out of your account.
 
-USAGE
-  ggt logout
-
-EXAMPLES
-  $ ggt logout
+Usage
+      ggt logout
 "
 `;
 
 exports[`root > when open is given > prints the usage when --help is passed 1`] = `
-"Open a Gadget location in your browser.
+"This command opens a specific Gadget page in your browser, allowing you to directly access
+various parts of your application's interface such as logs, permissions, data views, or
+schemas.
 
-USAGE
+Usage
+      ggt open [LOCATION] [model_name] [--show-all] [options]
 
-  ggt open [LOCATION] [MODEL] [--show-all]
-           [--app=<name>] [--env=<name>]
+      LOCATION: specifies the part of Gadget to open, by default it'll open the apps home page:
 
-EXAMPLES
+      + logs                Opens logs
+      + permissions         Opens permissions
+      + data                Opens data editor for a specific model
+      + schema              Opens schema editor for a specific model
 
-  $ ggt open
-  $ ggt open logs
-  $ ggt open permissions
-  $ ggt open data modelA
-  $ ggt open schema modelA
-  $ ggt open data --show-all
-  $ ggt open schema --show-all
+Options
+      -a, --app <app_name>   Selects the application to open in your browser. Default set on ".gadget/sync.json"
+      -e, --env <env_name>   Selects the environment to open in your browser. Default set on ".gadget/sync.json"
+      --show-all             Shows all schema, or data options by listing your available models
 
-ARGUMENTS
+Examples
+      Opens editor home
+      $ ggt open
 
-  LOCATION
-    The location to open in the browser.
-
-    Can be one of the following:
-      logs         The log viewer
-      permissions  The permissions settings
-      data         The data viewer for the chosen model
-      schema       The schema viewer for the chosen model
-
-    Defaults to opening the editor.
-
-  MODEL
-    The model to open in the browser.
-
-    Only required for the "data" and "schema" locations.
-
-FLAGS
-
-  -a, --app, --application=<name>
-    The application to open.
-
-    Defaults to the application within the ".gadget/sync.json"
-    file in the current directory or any parent directories.
-
-  -e, --env, --environment=<name>
-    The environment to open.
-
-    Defaults to the environment within the ".gadget/sync.json"
-    file in the current directory or any parent directories.
-
-  --show-all
-    Makes "ggt open" display available models to open rather than
-    exiting with an error if a model is not specified.
-
-    Defaults to false.
-
-Run "ggt open -h" for less information.
+      Opens logs 
+      $ ggt open logs 
+      
+      Opens permissions
+      $ ggt open permissions
+      
+      Opens data editor for the 'post' model
+      $ ggt open data post
+      
+      Opens schema for 'post' model
+      $ ggt open schema post
+      
+      Shows all models available in the data editor
+      $ ggt open data -show-all
+      
+      Shows all models available in the schema viewer
+      $ ggt open schema --show-all
+      
+      Opens data editor for 'post' model of app 'myBlog' in the 'staging' environment 
+      $ ggt open data post --app myBlog --env staging
 "
 `;
 
 exports[`root > when open is given > prints the usage when -h is passed 1`] = `
-"Open a Gadget location in your browser.
+"This command opens a specific Gadget page in your browser, allowing you to directly access
+various parts of your application's interface such as logs, permissions, data views, or
+schemas.
 
-USAGE
-  ggt open [LOCATION] [MODEL]
+Usage
+      ggt open [LOCATION] [model_name] [--show-all] [options]
 
-EXAMPLES
-  $ ggt open
-  $ ggt open logs
-  $ ggt open permissions
-  $ ggt open data modelA
-  $ ggt open schema modelA
-  $ ggt open data --show-all
-  $ ggt open schema --show-all
+      LOCATION: specifies the part of Gadget to open, by default it'll open the apps home page:
 
-ARGUMENTS
-  LOCATION    The location to open
-  MODEL       The model to open
+      + logs                Opens logs
+      + permissions         Opens permissions
+      + data                Opens data editor for a specific model
+      + schema              Opens schema editor for a specific model
 
-FLAGS
-  -a, --app=<name>      The application to open
-  -e, --env=<env>       The environment to open
-      --show-all        Show all available models to open
+Options
+      -a, --app <app_name>   Selects the application to open in your browser. Default set on ".gadget/sync.json"
+      -e, --env <env_name>   Selects the environment to open in your browser. Default set on ".gadget/sync.json"
+      --show-all             Shows all schema, or data options by listing your available models
 
-Run "ggt open --help" for more information.
+Examples
+      Opens editor home
+      $ ggt open
+
+      Opens logs 
+      $ ggt open logs 
+      
+      Opens permissions
+      $ ggt open permissions
+      
+      Opens data editor for the 'post' model
+      $ ggt open data post
+      
+      Opens schema for 'post' model
+      $ ggt open schema post
+      
+      Shows all models available in the data editor
+      $ ggt open data -show-all
+      
+      Shows all models available in the schema viewer
+      $ ggt open schema --show-all
+      
+      Opens data editor for 'post' model of app 'myBlog' in the 'staging' environment 
+      $ ggt open data post --app myBlog --env staging
 "
 `;
 
 exports[`root > when pull is given > prints the usage when --help is passed 1`] = `
-"Pull your environment's files to your local filesystem.
-Changes are tracked from the last "ggt dev", "ggt push", or
-"ggt pull" run locally.
+"Pulls your environment files to your local directory.
 
-If you have un-pushed changes, and "--force" is not passed,
-you will be prompted to discard them or abort the pull.
+This command first tracks changes in your local directory since the last sync. If changes are
+detected, you will be prompted to discard them or abort the pull.
 
-USAGE
+Usage
+      ggt pull [options]
 
-  ggt pull [--app=<name>] [--env=<name>] [--force]
-           [--allow-unknown-directory] [--allow-different-app]
+Options
+      -a, --app <app_name>           Selects the app to pull your environment changes from. Default set on ".gadget/sync.json"
+      --from, -e, --env <env_name>   Selects the environment to pull changes from. Default set on ".gadget/sync.json"
+      --force                        Forces a pull by discarding any changes made on your local directory since last sync
+      --allow-different-directory    Pulls changes from any environment directory, even if the ".gadget/sync.json" file is missing
+      --allow-different-app          Pulls changes to a different app using --app command, instead of the one in the “.gadget/sync.json” file
 
-EXAMPLES
-
-  $ ggt pull
-  $ ggt pull --env=staging
-  $ ggt pull --env=staging --force
-  $ ggt pull --env=staging --force --allow-unknown-directory
-
-FLAGS
-
-  -a, --app, --application=<name>
-    The application to pull files from.
-
-    Defaults to the application within the ".gadget/sync.json"
-    file in the current directory or any parent directories.
-
-  -e, --env, --environment=<name>
-    The environment to pull files from.
-
-    Defaults to the environment within the ".gadget/sync.json"
-    file in the current directory or any parent directories.
-
-  -f, --force
-    Discard any changes made to your local filesystem
-    since the last "ggt dev", "ggt push", or "ggt pull".
-
-    Defaults to false.
-
-  --allow-unknown-directory
-    Allows "ggt pull" to continue when the current directory, nor
-    any parent directories, contain a ".gadget/sync.json" file
-    within it.
-
-    Defaults to false.
-
-  --allow-different-app
-    Allows "ggt pull" to continue with a different "--app" than the
-    one found within the ".gadget/sync.json" file.
-
-    Defaults to false.
-
-Run "ggt pull -h" for less information.
+Examples
+      Pull all development environment changes by discarding any changes made locally
+      $ ggt pull --env development --force
 "
 `;
 
 exports[`root > when pull is given > prints the usage when -h is passed 1`] = `
-"Pull your environment's files to your local filesystem.
-Changes are tracked from the last "ggt dev", "ggt push", or
-"ggt pull" run locally.
+"Pulls your environment files to your local directory.
 
-USAGE
-  ggt pull
+This command first tracks changes in your local directory since the last sync. If changes are
+detected, you will be prompted to discard them or abort the pull.
 
-EXAMPLES
-  $ ggt pull
-  $ ggt pull --env=staging
-  $ ggt pull --env=staging --force
+Usage
+      ggt pull [options]
 
-FLAGS
-  -a, --app=<name>   The application to pull files from
-  -e, --env=<name>   The environment to pull files from
-      --force        Discard changes to your local filesystem
+Options
+      -a, --app <app_name>           Selects the app to pull your environment changes from. Default set on ".gadget/sync.json"
+      --from, -e, --env <env_name>   Selects the environment to pull changes from. Default set on ".gadget/sync.json"
+      --force                        Forces a pull by discarding any changes made on your local directory since last sync
+      --allow-different-directory    Pulls changes from any environment directory, even if the ".gadget/sync.json" file is missing
+      --allow-different-app          Pulls changes to a different app using --app command, instead of the one in the “.gadget/sync.json” file
 
-  Run "ggt pull --help" for more information.
+Examples
+      Pull all development environment changes by discarding any changes made locally
+      $ ggt pull --env development --force
 "
 `;
 
 exports[`root > when push is given > prints the usage when --help is passed 1`] = `
-"Push your local files to your environment's filesystem.
-Changes are tracked from the last "ggt dev", "ggt push", or
-"ggt pull" run locally.
+"Pushes your local files to your environment directory.
 
-If your environment has un-pulled changes, and "--force" is not passed,
-you will be prompted to discard them or abort the push.
+This command first tracks changes in your environment directory since the last sync.
+If changes are detected, you will be prompted to discard them or abort the push.
 
-USAGE
+Usage
+      ggt push [options]
 
-  ggt push [--app=<name>] [--env=<name>] [--force]
-           [--allow-unknown-directory] [--allow-different-app]
+Options
+      -a, --app <app_name>           Selects the app to push local changes to. Default set on ".gadget/sync.json"
+      --from, -e, --env <env_name>   Selects the environment to push local changes to. Default set on ".gadget/sync.json"
+      --force                        Forces a push by discarding any changes made on your environment directory since last sync
+      --allow-different-directory    Pushes changes from any local directory with existing files, even if the ".gadget/sync.json" file is missing
+      --allow-different-app          Pushes changes to an app using --app command, instead of the one in the “.gadget/sync.json” file
 
-EXAMPLES
-
-  $ ggt push
-  $ ggt push --env=staging
-  $ ggt push --env=staging --force
-  $ ggt push --env=staging --force --allow-unknown-directory
-
-FLAGS
-
-  -a, --app, --application=<name>
-    The application to push files to.
-
-    Defaults to the application within the ".gadget/sync.json"
-    file in the current directory or any parent directories.
-
-  -e, --env, --environment=<name>
-    The environment to push files to.
-
-    Defaults to the environment within the ".gadget/sync.json"
-    file in the current directory or any parent directories.
-
-  -f, --force
-    Discard any changes made to your environment's filesystem
-    since the last "ggt dev", "ggt push", or "ggt pull".
-
-    Defaults to false.
-
-  --allow-unknown-directory
-    Allows "ggt push" to continue when the current directory, nor
-    any parent directories, contain a ".gadget/sync.json" file
-    within it.
-
-    Defaults to false.
-
-  --allow-different-app
-    Allows "ggt push" to continue with a different "--app" than the
-    one found within the ".gadget/sync.json" file.
-
-    Defaults to false.
-
-Run "ggt push -h" for less information.
+Examples
+      Push all local changes to the main environment by discarding any changes made on main
+      $ ggt push --env main --force
 "
 `;
 
 exports[`root > when push is given > prints the usage when -h is passed 1`] = `
-"Push your local files to your environment's filesystem.
-Changes are tracked from the last "ggt dev", "ggt push", or
-"ggt pull" run locally.
+"Pushes your local files to your environment directory.
 
-USAGE
-  ggt push
+This command first tracks changes in your environment directory since the last sync.
+If changes are detected, you will be prompted to discard them or abort the push.
 
-EXAMPLES
-  $ ggt push
-  $ ggt push --env=staging
-  $ ggt push --env=staging --force
+Usage
+      ggt push [options]
 
-FLAGS
-  -a, --app=<name>   The application to push files to
-  -e, --env=<name>   The environment to push files to
-      --force        Discard changes to your environment's filesystem
+Options
+      -a, --app <app_name>           Selects the app to push local changes to. Default set on ".gadget/sync.json"
+      --from, -e, --env <env_name>   Selects the environment to push local changes to. Default set on ".gadget/sync.json"
+      --force                        Forces a push by discarding any changes made on your environment directory since last sync
+      --allow-different-directory    Pushes changes from any local directory with existing files, even if the ".gadget/sync.json" file is missing
+      --allow-different-app          Pushes changes to an app using --app command, instead of the one in the “.gadget/sync.json” file
 
-  Run "ggt push --help" for more information.
+Examples
+      Push all local changes to the main environment by discarding any changes made on main
+      $ ggt push --env main --force
 "
 `;
 
 exports[`root > when status is given > prints the usage when --help is passed 1`] = `
-"Show file changes since your last dev, push, or pull.
+"Shows file changes since last sync (e.g. $ggt dev, push, deploy etc.)
 
-USAGE
-
-  ggt status
-
-EXAMPLES
-
-  $ ggt status
+Usage
+      ggt status
 "
 `;
 
 exports[`root > when status is given > prints the usage when -h is passed 1`] = `
-"Show file changes since your last dev, push, or pull.
+"Shows file changes since last sync (e.g. $ggt dev, push, deploy etc.)
 
-USAGE
-
-  ggt status
-
-EXAMPLES
-
-  $ ggt status
+Usage
+      ggt status
 "
 `;
 
 exports[`root > when version is given > prints the usage when --help is passed 1`] = `
 "Print this version of ggt.
 
-USAGE
-  ggt version
+Usage
+      ggt version
 
-EXAMPLES
-  $ ggt version
+Updating ggt
+      When there is a new release of ggt, running ggt will show you a message letting you
+      know that an update is available.
 "
 `;
 
 exports[`root > when version is given > prints the usage when -h is passed 1`] = `
 "Print this version of ggt.
 
-USAGE
-  ggt version
+Usage
+      ggt version
 
-EXAMPLES
-  $ ggt version
+Updating ggt
+      When there is a new release of ggt, running ggt will show you a message letting you
+      know that an update is available.
 "
 `;
 
 exports[`root > when whoami is given > prints the usage when --help is passed 1`] = `
 "Show the name and email address of the currently logged in user.
 
-USAGE
-  ggt whoami
-
-EXAMPLES
-  $ ggt whoami
+Usage
+      ggt whoami
 "
 `;
 
 exports[`root > when whoami is given > prints the usage when -h is passed 1`] = `
 "Show the name and email address of the currently logged in user.
 
-USAGE
-  ggt whoami
-
-EXAMPLES
-  $ ggt whoami
+Usage
+      ggt whoami
 "
 `;

--- a/spec/commands/root.spec.ts
+++ b/spec/commands/root.spec.ts
@@ -62,10 +62,10 @@ describe("root", () => {
     expectStdout().toMatchInlineSnapshot(`
       "The command-line interface for Gadget.
 
-      USAGE
+      Usage
         ggt [COMMAND]
 
-      COMMANDS
+      Commands
         dev              Start developing your application
         deploy           Deploy your environment to production
         status           Show your local and environment's file changes
@@ -78,7 +78,7 @@ describe("root", () => {
         whoami           Print the currently logged in account
         version          Print this version of ggt
 
-      FLAGS
+      Flags
         -h, --help       Print how to use a command
         -v, --verbose    Print more verbose output
             --telemetry  Enable telemetry

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -26,112 +26,29 @@ export const args = {
   "--allow-charges": { type: Boolean },
 };
 
-export const usage: Usage = (ctx) => {
-  if (ctx.args["-h"]) {
-    return sprint`
-      Deploy an environment to production.
-
-      Your local files must match your environment's files
-      before you can deploy. Changes are tracked from
-      the last "ggt dev", "ggt push", or "ggt pull" run locally.
-
-      {bold USAGE}
-        ggt deploy
-
-      {bold EXAMPLES}
-        $ ggt deploy
-        $ ggt deploy --from=staging
-        $ ggt deploy --from=staging --force
-        $ ggt deploy --from=staging --force --allow-problems
-
-      {bold FLAGS}
-        -a, --app=<name>      The application to deploy
-        -e, --from=<env>      The environment to deploy from
-            --force           Discard changes to your environment's filesystem
-            --allow-problems  Deploy regardless of any problems the environment has
-            --allow-charges   Deploy even if doing so will add charges to your account
-
-      Run "ggt deploy --help" for more information.
-    `;
-  }
-
+export const usage: Usage = (_ctx) => {
   return sprint`
-    Deploy an environment to production.
+  Deploys your app to production.
 
-    Your local files must match your environment's files
-    before you can deploy. Changes are tracked from
-    the last "ggt dev", "ggt push", or "ggt pull" run locally.
+  This command first performs a sync to ensure that your local and environment directories
+  match, changes are tracked since last sync. If any conflicts are detected, they must be
+  resolved before deployment.
 
-    If your local files don't match your environment's files, you will
-    be prompted to push your local files before you can deploy.
-
-    If your environment has un-pulled changes, and "--force" is not
-    passed, you will be prompted to {underline discard them} or abort the deploy.
-
-    {bold USAGE}
-
-      ggt deploy [--app=<name>] [--from=<env>] [--force]
-                 [--allow-problems] [--allow-charges]
-
-    {bold EXAMPLES}
-
-      $ ggt deploy
-      $ ggt deploy --from=staging
-      $ ggt deploy --from=staging --force
-      $ ggt deploy --from=staging --force --allow-problems
-      $ ggt deploy --from=staging --force --allow-problems --allow-charges
-
-    {bold FLAGS}
-
-      -a, --app, --application=<name>
-        The application to deploy.
-
-        Defaults to the application within the ".gadget/sync.json"
-        file in the current directory or any parent directories.
-
-      -e, --env, --environment, --from=<name>
-        The environment to deploy from.
-
-        Defaults to the environment within the ".gadget/sync.json"
-        file in the current directory or any parent directories.
-
-      -f, --force
-        Discard any changes made to your environment's filesystem
-        since the last "ggt dev", "ggt push", or "ggt pull".
-
-        Defaults to false.
-
-      --allow-problems, --allow-issues
-        Deploy your environment to production regardless of any problems
-        it may have.
-
-        These problems may include:
-          • Gelly syntax errors
-          • TypeScript errors
-          • Models with missing fields
-
-        Defaults to false.
-
-      --allow-charges
-        Allows "ggt deploy" to continue when deploying your environment
-        to production will add charges to your account.
-
-        Defaults to false.
-
-      --allow-unknown-directory
-        Allows "ggt deploy" to continue when the current directory, nor
-        any parent directories, contain a ".gadget/sync.json" file
-        within it.
-
-        Defaults to false.
-
-      --allow-different-app
-        Allows "ggt deploy" to continue with a different "--app" than the
-        one found within the ".gadget/sync.json" file.
-
-        Defaults to false.
-
-    Run "ggt deploy -h" for less information.
+  {gray Usage}
+        $ ggt deploy [options]
+  
+  {gray Options}
+        -a, --app <app_name>           Selects a specific app to deploy. Default set on ".gadget/sync.json"
+        --from, -e, --env <env_name>   Selects a specific environment to sync and deploy from. Default set on ".gadget/sync.json"
+        --force                        Deploys by discarding any changes made to the environment directory since last sync
+        --allow-different-directory    Deploys from any local directory with existing files, even if the ".gadget/sync.json" file is missing
+        --allow-different-app          Deploys a different app using the --app command, instead of the one specified in the “.gadget/sync.json” file
+        --allow-problems               Deploys despite any existing issues found in the app (gelly errors, typescript errors etc.)
+        --allow-charges                Deploys even if it results in additional charges to your plan
+  
+  {gray Examples}
+        Deploys code from the staging environment of a myBlog
+        {cyanBright $ ggt deploy -a myBlog -from staging} 
 `;
 };
 

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -38,122 +38,50 @@ export const args = {
   "--file-watch-rename-timeout": { type: Number, default: ms("1.25s") },
 } satisfies ArgsDefinition;
 
-export const usage: Usage = (ctx) => {
-  if (ctx.args["-h"]) {
-    return sprint`
-      Develop your app by synchronizing your local files with your
-      environment's files, in real-time. Changes are tracked from
-      the last "ggt dev", "ggt push", or "ggt pull" run locally.
-
-      {bold USAGE}
-        ggt dev [DIRECTORY]
-
-      {bold EXAMPLES}
-        $ ggt dev
-        $ ggt dev ~/gadget/example
-        $ ggt dev ~/gadget/example
-        $ ggt dev ~/gadget/example --app=example
-        $ ggt dev ~/gadget/example --app=example --env=development --prefer=local
-
-      {bold ARGUMENTS}
-        DIRECTORY    The directory to synchronize files to (default: ".")
-
-      {bold FLAGS}
-        -a, --app=<name>           The application to synchronize files with
-        -e, --env=<name>           The environment to synchronize files with
-            --prefer=<filesystem>  Prefer "local" or "environment" conflicting changes
-
-        Run "ggt dev --help" for more information.
-    `;
-  }
-
+export const usage: Usage = (_ctx) => {
   return sprint`
-    Develop your app by synchronizing your local files with your
-    environment's files, in real-time. Changes are tracked from
-    the last "ggt dev", "ggt push", or "ggt pull" run locally.
+  Clones your Gadget environment's files to your local machine and keeps it in sync, in order to
+  enable local development with your text editor and source code with Git.
 
-    While "ggt dev" is running, changes on your local filesystem are
-    immediately pushed to your environment, while file changes on
-    your environment are immediately pulled to your local filesystem.
+  If your app's local directory already exists, this command first performs a sync to ensure
+  that your local and environment directories match, changes are tracked since last sync. If any 
+  conflicts are detected, they must be resolved before development starts.
 
-    If conflicting changes are detected, and "--prefer" is not passed,
-    you will be prompted to choose which changes to keep before
-    "ggt dev" resumes.
+  {gray Usage}
+        $ ggt dev [DIRECTORY] [options]
 
-    "ggt dev" looks for an ".ignore" file to exclude files and
-    directories from being pushed or pulled. The format is identical
-    to Git's.
+        DIRECTORY: The directory to sync files to (default: the current directory)
+  
+  {gray Options}
+        -a, --app <app_name>        Selects the app to sync files with. Default set on ".gadget/sync.json"
+        -e, --env <env_name>        Selects the environment to sync files with. Default set on ".gadget/sync.json"
+        --prefer <source>           Auto-select changes from 'local' or 'environment' source on conflict
+        --allow-unknown-directory   Syncs to any local directory with existing files, even if the ".gadget/sync.json" file is missing
+        --allow-different-app       Syncs with a different app using the --app command, instead of the one specified in the .gadget/sync.json file
 
-    The following files and directories are always ignored:
-      • .DS_Store
-      • .gadget
-      • .git
-      • node_modules
+  {gray Ignoring files}
+        ggt dev uses a .ignore file, similar to .gitignore, to exclude specific files and 
+        folders from syncing. These files are always ignored:
 
-    Note:
-      • "ggt dev" only works with development environments
-      • "ggt dev" only supports "yarn" v1 for installing dependencies
-      • Avoid deleting or moving all of your files while "ggt dev" is running
+        • .DS_Store
+        • .gadget
+        • .git
+        • node_modules
+  
+  {gray Notes}
+        • "ggt dev" only works with development environments
+        • "ggt dev" only supports "yarn" v1 for installing dependencies
+        • Avoid deleting or moving all of your files while "ggt dev" is running
+  
+  {gray Examples}
+        sync an app in a custom path 
+        {cyanBright $ ggt dev ~/myGadgetApps/myBlog --app myBlogApp}
+        
+        sync with a specific environment and preselect all local changes on conflicts
+        {cyanBright $ ggt dev --env main --prefer local}
 
-    {bold USAGE}
-
-      ggt dev [DIRECTORY] [--app=<name>] [--env=<name>] [--prefer=<filesystem>]
-                          [--allow-unknown-directory] [--allow-different-app]
-
-    {bold EXAMPLES}
-
-      $ ggt dev
-      $ ggt dev ~/gadget/example
-      $ ggt dev ~/gadget/example
-      $ ggt dev ~/gadget/example --app=example
-      $ ggt dev ~/gadget/example --app=example --env=development --prefer=local
-
-    {bold ARGUMENTS}
-
-      DIRECTORY
-        The path to the directory to synchronize files to.
-        The directory will be created if it does not exist.
-
-        Defaults to the current working directory. (default: ".")
-
-    {bold FLAGS}
-
-      -a, --app, --application=<name>
-        The application to synchronize files with.
-
-        Defaults to the application within the ".gadget/sync.json"
-        file in the chosen directory or any parent directories.
-
-      -e, --env, --environment=<name>
-        The development environment to synchronize files with.
-
-        Defaults to the environment within the ".gadget/sync.json"
-        file in the chosen directory or any parent directories.
-
-      --prefer=<filesystem>
-        Which filesystem's changes to automatically keep when
-        conflicting changes are detected.
-
-        Must be one of "local" or "environment".
-
-        If not provided, "ggt dev" will pause when conflicting changes
-        are detected and you will be prompted to choose which changes to
-        keep before "ggt dev" resumes.
-
-      --allow-unknown-directory
-        Allows "ggt dev" to continue when the chosen directory, nor
-        any parent directories, contain a ".gadget/sync.json" file
-        within it.
-
-        Defaults to false.
-
-      --allow-different-app
-        Allows "ggt dev" to continue with a different "--app" than the
-        one found within the ".gadget/sync.json" file.
-
-        Defaults to false.
-
-    Run "ggt dev -h" for less information.
+        sync a custom path with a specific app, environment and preselect all changes from local on conflicts
+        {cyanBright $ ggt dev ~/gadget/example --app=example --env=development --prefer=local}
   `;
 };
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -7,13 +7,10 @@ import { printTable } from "../services/output/table.js";
 import { getUserOrLogin } from "../services/user/user.js";
 
 export const usage: Usage = () => sprint`
-    List your available applications.
+    List the apps available to the currently logged-in user.
 
-    {bold USAGE}
-      ggt list
-
-    {bold EXAMPLES}
-      $ ggt list
+    {bold Usage}
+          ggt list
 `;
 
 export const command: Command = async (ctx) => {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -12,11 +12,8 @@ import { getUser } from "../services/user/user.js";
 export const usage: Usage = () => sprint`
     Log in to your account.
 
-    {bold USAGE}
-      ggt login
-
-    {bold EXAMPLES}
-      $ ggt login
+    {bold Usage}
+          ggt login
 `;
 
 export const login: Command = async (ctx): Promise<void> => {

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -6,11 +6,8 @@ import { readSession, writeSession } from "../services/user/session.js";
 export const usage: Usage = () => sprint`
     Log out of your account.
 
-    {bold USAGE}
-      ggt logout
-
-    {bold EXAMPLES}
-      $ ggt logout
+    {bold Usage}
+          ggt logout
 `;
 
 export const command: Command = (_ctx) => {

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -17,93 +17,51 @@ export const args = {
   "--show-all": { type: Boolean },
 };
 
-export const usage: Usage = (ctx) => {
-  if (ctx.args["-h"]) {
-    return sprint`
-      Open a Gadget location in your browser.
-
-      {bold USAGE}
-        ggt open [LOCATION] [MODEL]
-
-      {bold EXAMPLES}
-        $ ggt open
-        $ ggt open logs
-        $ ggt open permissions
-        $ ggt open data modelA
-        $ ggt open schema modelA
-        $ ggt open data --show-all
-        $ ggt open schema --show-all
-
-      {bold ARGUMENTS}
-        LOCATION    The location to open
-        MODEL       The model to open
-
-      {bold FLAGS}
-        -a, --app=<name>      The application to open
-        -e, --env=<env>       The environment to open
-            --show-all        Show all available models to open
-
-      Run "ggt open --help" for more information.
-    `;
-  }
-
+export const usage: Usage = (_ctx) => {
   return sprint`
-    Open a Gadget location in your browser.
+  This command opens a specific Gadget page in your browser, allowing you to directly access
+  various parts of your application's interface such as logs, permissions, data views, or
+  schemas.
 
-    {bold USAGE}
+  {gray Usage}
+        ggt open [LOCATION] [model_name] [--show-all] [options]
+  
+        LOCATION: specifies the part of Gadget to open, by default it'll open the apps home page:
 
-      ggt open [LOCATION] [MODEL] [--show-all]
-               [--app=<name>] [--env=<name>]
+        + logs                Opens logs
+        + permissions         Opens permissions
+        + data                Opens data editor for a specific model
+        + schema              Opens schema editor for a specific model
 
-    {bold EXAMPLES}
+  {gray Options}
+        -a, --app <app_name>   Selects the application to open in your browser. Default set on ".gadget/sync.json"
+        -e, --env <env_name>   Selects the environment to open in your browser. Default set on ".gadget/sync.json"
+        --show-all             Shows all schema, or data options by listing your available models
+  
+  {gray Examples}
+        Opens editor home
+        {cyanBright $ ggt open}
 
-      $ ggt open
-      $ ggt open logs
-      $ ggt open permissions
-      $ ggt open data modelA
-      $ ggt open schema modelA
-      $ ggt open data --show-all
-      $ ggt open schema --show-all
-
-    {bold ARGUMENTS}
-
-      LOCATION
-        The location to open in the browser.
-
-        Can be one of the following:
-          logs         The log viewer
-          permissions  The permissions settings
-          data         The data viewer for the chosen model
-          schema       The schema viewer for the chosen model
-
-        Defaults to opening the editor.
-
-      MODEL
-        The model to open in the browser.
-
-        Only required for the "data" and "schema" locations.
-
-    {bold FLAGS}
-
-      -a, --app, --application=<name>
-        The application to open.
-
-        Defaults to the application within the ".gadget/sync.json"
-        file in the current directory or any parent directories.
-
-      -e, --env, --environment=<name>
-        The environment to open.
-
-        Defaults to the environment within the ".gadget/sync.json"
-        file in the current directory or any parent directories.
-
-      --show-all
-        Makes "ggt open" display available models to open rather than
-        exiting with an error if a model is not specified.
-
-        Defaults to false.
-
-    Run "ggt open -h" for less information.
+        Opens logs 
+        {cyanBright $ ggt open logs} 
+        
+        Opens permissions
+        {cyanBright $ ggt open permissions}
+        
+        Opens data editor for the 'post' model
+        {cyanBright $ ggt open data post}
+        
+        Opens schema for 'post' model
+        {cyanBright $ ggt open schema post}
+        
+        Shows all models available in the data editor
+        {cyanBright $ ggt open data -show-all}
+        
+        Shows all models available in the schema viewer
+        {cyanBright $ ggt open schema --show-all}
+        
+        Opens data editor for 'post' model of app 'myBlog' in the 'staging' environment 
+        {cyanBright $ ggt open data post --app myBlog --env staging}
   `;
 };
 

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -12,84 +12,26 @@ export const args = {
   "--force": { type: Boolean, alias: "-f" },
 } satisfies ArgsDefinition;
 
-export const usage: Usage = (ctx) => {
-  if (ctx.args["-h"]) {
-    return sprint`
-      Pull your environment's files to your local filesystem.
-      Changes are tracked from the last "ggt dev", "ggt push", or
-      "ggt pull" run locally.
-
-      {bold USAGE}
-        ggt pull
-
-      {bold EXAMPLES}
-        $ ggt pull
-        $ ggt pull --env=staging
-        $ ggt pull --env=staging --force
-
-      {bold FLAGS}
-        -a, --app=<name>   The application to pull files from
-        -e, --env=<name>   The environment to pull files from
-            --force        Discard changes to your local filesystem
-
-        Run "ggt pull --help" for more information.
-    `;
-  }
-
+export const usage: Usage = (_ctx) => {
   return sprint`
-    Pull your environment's files to your local filesystem.
-    Changes are tracked from the last "ggt dev", "ggt push", or
-    "ggt pull" run locally.
+  Pulls your environment files to your local directory.
 
-    If you have un-pushed changes, and "--force" is not passed,
-    you will be prompted to {underline discard them} or abort the pull.
+  This command first tracks changes in your local directory since the last sync. If changes are
+  detected, you will be prompted to discard them or abort the pull.
 
-    {bold USAGE}
-
-      ggt pull [--app=<name>] [--env=<name>] [--force]
-               [--allow-unknown-directory] [--allow-different-app]
-
-    {bold EXAMPLES}
-
-      $ ggt pull
-      $ ggt pull --env=staging
-      $ ggt pull --env=staging --force
-      $ ggt pull --env=staging --force --allow-unknown-directory
-
-    {bold FLAGS}
-
-      -a, --app, --application=<name>
-        The application to pull files from.
-
-        Defaults to the application within the ".gadget/sync.json"
-        file in the current directory or any parent directories.
-
-      -e, --env, --environment=<name>
-        The environment to pull files from.
-
-        Defaults to the environment within the ".gadget/sync.json"
-        file in the current directory or any parent directories.
-
-      -f, --force
-        Discard any changes made to your local filesystem
-        since the last "ggt dev", "ggt push", or "ggt pull".
-
-        Defaults to false.
-
-      --allow-unknown-directory
-        Allows "ggt pull" to continue when the current directory, nor
-        any parent directories, contain a ".gadget/sync.json" file
-        within it.
-
-        Defaults to false.
-
-      --allow-different-app
-        Allows "ggt pull" to continue with a different "--app" than the
-        one found within the ".gadget/sync.json" file.
-
-        Defaults to false.
-
-    Run "ggt pull -h" for less information.
+  {gray Usage}
+        ggt pull [options]
+  
+  {gray Options}
+        -a, --app <app_name>           Selects the app to pull your environment changes from. Default set on ".gadget/sync.json"
+        --from, -e, --env <env_name>   Selects the environment to pull changes from. Default set on ".gadget/sync.json"
+        --force                        Forces a pull by discarding any changes made on your local directory since last sync
+        --allow-different-directory    Pulls changes from any environment directory, even if the ".gadget/sync.json" file is missing
+        --allow-different-app          Pulls changes to a different app using --app command, instead of the one in the “.gadget/sync.json” file
+  
+  {gray Examples}
+        Pull all development environment changes by discarding any changes made locally
+        {cyanBright $ ggt pull --env development --force}
   `;
 };
 

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -12,84 +12,26 @@ export const args = {
   "--force": { type: Boolean, alias: "-f" },
 } satisfies ArgsDefinition;
 
-export const usage: Usage = (ctx) => {
-  if (ctx.args["-h"]) {
-    return sprint`
-      Push your local files to your environment's filesystem.
-      Changes are tracked from the last "ggt dev", "ggt push", or
-      "ggt pull" run locally.
-
-      {bold USAGE}
-        ggt push
-
-      {bold EXAMPLES}
-        $ ggt push
-        $ ggt push --env=staging
-        $ ggt push --env=staging --force
-
-      {bold FLAGS}
-        -a, --app=<name>   The application to push files to
-        -e, --env=<name>   The environment to push files to
-            --force        Discard changes to your environment's filesystem
-
-        Run "ggt push --help" for more information.
-    `;
-  }
-
+export const usage: Usage = (_ctx) => {
   return sprint`
-    Push your local files to your environment's filesystem.
-    Changes are tracked from the last "ggt dev", "ggt push", or
-    "ggt pull" run locally.
+  Pushes your local files to your environment directory.
 
-    If your environment has un-pulled changes, and "--force" is not passed,
-    you will be prompted to {underline discard them} or abort the push.
+  This command first tracks changes in your environment directory since the last sync.
+  If changes are detected, you will be prompted to discard them or abort the push.
 
-    {bold USAGE}
-
-      ggt push [--app=<name>] [--env=<name>] [--force]
-               [--allow-unknown-directory] [--allow-different-app]
-
-    {bold EXAMPLES}
-
-      $ ggt push
-      $ ggt push --env=staging
-      $ ggt push --env=staging --force
-      $ ggt push --env=staging --force --allow-unknown-directory
-
-    {bold FLAGS}
-
-      -a, --app, --application=<name>
-        The application to push files to.
-
-        Defaults to the application within the ".gadget/sync.json"
-        file in the current directory or any parent directories.
-
-      -e, --env, --environment=<name>
-        The environment to push files to.
-
-        Defaults to the environment within the ".gadget/sync.json"
-        file in the current directory or any parent directories.
-
-      -f, --force
-        Discard any changes made to your environment's filesystem
-        since the last "ggt dev", "ggt push", or "ggt pull".
-
-        Defaults to false.
-
-      --allow-unknown-directory
-        Allows "ggt push" to continue when the current directory, nor
-        any parent directories, contain a ".gadget/sync.json" file
-        within it.
-
-        Defaults to false.
-
-      --allow-different-app
-        Allows "ggt push" to continue with a different "--app" than the
-        one found within the ".gadget/sync.json" file.
-
-        Defaults to false.
-
-    Run "ggt push -h" for less information.
+  {gray Usage}
+        ggt push [options]
+  
+  {gray Options}
+        -a, --app <app_name>           Selects the app to push local changes to. Default set on ".gadget/sync.json"
+        --from, -e, --env <env_name>   Selects the environment to push local changes to. Default set on ".gadget/sync.json"
+        --force                        Forces a push by discarding any changes made on your environment directory since last sync
+        --allow-different-directory    Pushes changes from any local directory with existing files, even if the ".gadget/sync.json" file is missing
+        --allow-different-app          Pushes changes to an app using --app command, instead of the one in the “.gadget/sync.json” file
+  
+  {gray Examples}
+        Push all local changes to the main environment by discarding any changes made on main
+        {cyanBright $ ggt push --env main --force}
   `;
 };
 

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -24,10 +24,10 @@ export const usage: Usage = () => {
   return sprint`
     The command-line interface for Gadget.
 
-    {bold USAGE}
+    {gray Usage}
       ggt [COMMAND]
 
-    {bold COMMANDS}
+    {gray Commands}
       dev              Start developing your application
       deploy           Deploy your environment to production
       status           Show your local and environment's file changes
@@ -40,7 +40,7 @@ export const usage: Usage = () => {
       whoami           Print the currently logged in account
       version          Print this version of ggt
 
-    {bold FLAGS}
+    {gray Flags}
       -h, --help       Print how to use a command
       -v, --verbose    Print more verbose output
           --telemetry  Enable telemetry

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -12,15 +12,10 @@ export const args = SyncJsonArgs;
 
 export const usage: Usage = () => {
   return sprint`
-    Show file changes since your last dev, push, or pull.
+    Shows file changes since last sync (e.g. $ggt dev, push, deploy etc.)
 
-    {bold USAGE}
-
-      ggt status
-
-    {bold EXAMPLES}
-
-      $ ggt status
+    {gray Usage}
+          ggt status
   `;
 };
 

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -6,11 +6,12 @@ import { sprint } from "../services/output/sprint.js";
 export const usage: Usage = () => sprint`
   Print this version of ggt.
 
-  {bold USAGE}
-    ggt version
-
-  {bold EXAMPLES}
-    $ ggt version
+  {gray Usage}
+        ggt version
+  
+  {gray Updating ggt}
+        When there is a new release of ggt, running ggt will show you a message letting you
+        know that an update is available.
 `;
 
 export const command: Command = (_ctx) => {

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -6,11 +6,8 @@ import { getUser } from "../services/user/user.js";
 export const usage: Usage = () => sprint`
     Show the name and email address of the currently logged in user.
 
-    {bold USAGE}
-      ggt whoami
-
-    {bold EXAMPLES}
-      $ ggt whoami
+    {gray Usage}
+          ggt whoami
 `;
 
 export const command: Command = async (ctx) => {


### PR DESCRIPTION
@mdamy made a really great CLI design doc: https://docs.google.com/document/d/1nNL12-9y_wdf4ANWDC1kvWOymkMM9B-4CWfuad3_tHo/edit

To better standardize ggt I've gone a head and copied most of the usages from it. Another decision was to remove the less verbose usage/help when using `-h` now it'll always be the same help regardless.