### PR TITLE
Add browser opening log statement in login command

### DIFF
--- a/.changeset/log-login-url.md
+++ b/.changeset/log-login-url.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Log the login URL for manual login in case of browser opening failure.

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -65,6 +65,7 @@ export const login: Command = async (ctx): Promise<void> => {
     url.searchParams.set("returnTo", `https://${config.domains.services}/auth/cli/callback?port=${port}`);
 
     try {
+      ctx.log.info("opening browser", { url: url.toString() });
       await open(url.toString());
       println({ ensureEmptyLineAbove: true })`
         We've opened Gadget's login page using your default browser.


### PR DESCRIPTION
If `open` fails to open the user's browser, but doesn't throw an error, then user's can't log manually log in themselves.

This logs the login URL so users can manually click the link.