### PR TITLE
Lazy load Sentry

### DIFF
--- a/src/ggt.ts
+++ b/src/ggt.ts
@@ -9,7 +9,7 @@ import { installJsonExtensions } from "./services/util/json.js";
 
 export const ggt = async (ctx = Context.init({ name: "ggt" })): Promise<void> => {
   installJsonExtensions();
-  installErrorHandlers(ctx);
+  await installErrorHandlers(ctx);
 
   try {
     let stopping = false;

--- a/src/services/output/log/structured.ts
+++ b/src/services/output/log/structured.ts
@@ -1,9 +1,9 @@
-import { addBreadcrumb as addSentryBreadcrumb } from "@sentry/node";
 import { config } from "../../config/config.js";
 import { env } from "../../config/env.js";
 import { unthunk, type Thunk } from "../../util/function.js";
 import { serializeError } from "../../util/object.js";
 import { output } from "../output.js";
+import { addSentryBreadcrumb } from "../sentry.js";
 import type { Fields } from "./field.js";
 import { formatters } from "./format/format.js";
 import { Level } from "./level.js";

--- a/src/services/output/report.ts
+++ b/src/services/output/report.ts
@@ -1,17 +1,13 @@
-import * as Sentry from "@sentry/node";
 import cleanStack from "clean-stack";
-import ms from "ms";
 import { randomUUID } from "node:crypto";
-import os from "node:os";
 import terminalLink from "terminal-link";
 import type { Context } from "../command/context.js";
-import { config } from "../config/config.js";
 import { env } from "../config/env.js";
 import { isAbortError } from "../util/is.js";
 import { serializeError } from "../util/object.js";
-import { packageJson } from "../util/package-json.js";
 import { workspaceRoot } from "../util/paths.js";
 import { println } from "./print.js";
+import { initSentry, sendErrorToSentry } from "./sentry.js";
 import { sprintln, type SprintOptions } from "./sprint.js";
 
 export const reportErrorAndExit = async (ctx: Context, cause: unknown): Promise<never> => {
@@ -30,61 +26,15 @@ export const reportErrorAndExit = async (ctx: Context, cause: unknown): Promise<
       return undefined as never;
     }
 
-    Sentry.captureException(error, {
-      event_id: error.id,
-      captureContext: {
-        user: ctx.user && {
-          id: String(ctx.user.id),
-          email: ctx.user.email,
-          username: ctx.user.name ?? undefined,
-        },
-        tags: {
-          application_id: ctx.app?.id,
-          arch: config.arch,
-          bug: error.isBug,
-          environment: env.value,
-          platform: config.platform,
-          shell: config.shell,
-          version: packageJson.version,
-        },
-        contexts: {
-          ctx: {
-            argv: process.argv,
-            args: ctx.args,
-          },
-          cause: error.cause ? serializeError(error.cause) : undefined,
-          app: {
-            app_name: packageJson.name,
-            app_version: packageJson.version,
-          },
-          device: {
-            name: os.hostname(),
-            family: os.type(),
-            arch: os.arch(),
-          },
-          runtime: {
-            name: process.release.name,
-            version: process.version,
-          },
-        },
-      },
-    });
-
-    await Sentry.flush(ms("2s"));
+    await sendErrorToSentry(ctx, error);
   } finally {
     process.exit(1);
   }
 };
 
-export const installErrorHandlers = (ctx: Context): void => {
+export const installErrorHandlers = async (ctx: Context): Promise<void> => {
   ctx.log.debug("installing error handlers");
-
-  Sentry.init({
-    dsn: "https://0c26e0d8afd94e77a88ee1c3aa9e7065@o250689.ingest.sentry.io/6703266",
-    enabled: env.productionLike && (ctx.args["--telemetry"] ?? false),
-    release: packageJson.version,
-    environment: packageJson.version.includes("experimental") ? "experimental" : "production",
-  });
+  await initSentry(ctx);
 
   const handleError = (error: unknown) => void reportErrorAndExit(ctx, error);
   process.once("uncaughtException", handleError);

--- a/src/services/output/sentry.ts
+++ b/src/services/output/sentry.ts
@@ -1,0 +1,82 @@
+import type * as SentryModule from "@sentry/node";
+import ms from "ms";
+import os from "node:os";
+import type { Context } from "../command/context.js";
+import { config } from "../config/config.js";
+import { env } from "../config/env.js";
+import { serializeError } from "../util/object.js";
+import { packageJson } from "../util/package-json.js";
+import type { GGTError } from "./report.js";
+
+let Sentry: typeof SentryModule | undefined;
+
+export const initSentry = async (ctx: Context): Promise<void> => {
+  if (!ctx.args["--telemetry"]) {
+    return;
+  }
+
+  Sentry = await import("@sentry/node");
+
+  Sentry.init({
+    dsn: "https://0c26e0d8afd94e77a88ee1c3aa9e7065@o250689.ingest.sentry.io/6703266",
+    enabled: env.productionLike && (ctx.args["--telemetry"] ?? false),
+    release: packageJson.version,
+    environment: packageJson.version.includes("experimental") ? "experimental" : "production",
+  });
+};
+
+export const sendErrorToSentry = async (ctx: Context, error: GGTError): Promise<void> => {
+  if (!Sentry) {
+    return;
+  }
+
+  Sentry.captureException(error, {
+    event_id: error.id,
+    captureContext: {
+      user: ctx.user && {
+        id: String(ctx.user.id),
+        email: ctx.user.email,
+        username: ctx.user.name ?? undefined,
+      },
+      tags: {
+        application_id: ctx.app?.id,
+        arch: config.arch,
+        bug: error.isBug,
+        environment: env.value,
+        platform: config.platform,
+        shell: config.shell,
+        version: packageJson.version,
+      },
+      contexts: {
+        ctx: {
+          argv: process.argv,
+          args: ctx.args,
+        },
+        cause: error.cause ? serializeError(error.cause) : undefined,
+        app: {
+          app_name: packageJson.name,
+          app_version: packageJson.version,
+        },
+        device: {
+          name: os.hostname(),
+          family: os.type(),
+          arch: os.arch(),
+        },
+        runtime: {
+          name: process.release.name,
+          version: process.version,
+        },
+      },
+    },
+  });
+
+  await Sentry.flush(ms("2s"));
+};
+
+export const addSentryBreadcrumb = (breadcrumb: SentryModule.Breadcrumb): void => {
+  if (!Sentry) {
+    return;
+  }
+
+  Sentry.addBreadcrumb(breadcrumb);
+};


### PR DESCRIPTION
`@sentry/node` is big and we only need to load  when `--telemetry` is enabled.