### PR TITLE
Dispose client after deploying

### DIFF
--- a/.changeset/fix-ggt-deploy-hanging.md
+++ b/.changeset/fix-ggt-deploy-hanging.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Fixed an issue causing `ggt deploy` to hang after deploying an app.

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -210,6 +210,9 @@ export const run: Run<DeployArgs> = async (ctx) => {
         currentStep = step as AppDeploymentSteps;
       }
     },
+    onComplete: async () => {
+      await syncJson.edit.dispose();
+    },
   });
 };
 


### PR DESCRIPTION
I was able to semi-reproduce the "ggt deploy hanging" issue by running `ggt deploy --allow-problems` while `ggt dev` was running at the same time.

Why did `ggt dev` have to be running and why did I have to pass `--allow-problems`? I have no idea, but after disposing the client like Harry suggested I wasn't able to reproduce the issue anymore 🎉 