### PR TITLE
Unsubscribe rather than disposing

### DIFF
--- a/.changeset/fix-ggt-deploy-confirm.md
+++ b/.changeset/fix-ggt-deploy-confirm.md
@@ -1,0 +1,5 @@
+---
+ggt: patch
+---
+
+Fix `ggt deploy` immediately exiting after confirmation.

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -172,7 +172,6 @@ export const run: Run<DeployArgs> = async (ctx) => {
       }
 
       if (status?.code === "Errored") {
-        subscription.unsubscribe();
         spinner?.fail(stepToSpinnerStart(syncJson, currentStep) + " " + ts());
 
         if (status.message) {
@@ -185,7 +184,6 @@ export const run: Run<DeployArgs> = async (ctx) => {
       }
 
       if (step === AppDeploymentSteps.COMPLETED) {
-        subscription.unsubscribe();
         spinner?.succeed(stepToSpinnerEnd(syncJson, currentStep));
 
         let message = sprint`{green Deploy successful!}`;
@@ -210,8 +208,8 @@ export const run: Run<DeployArgs> = async (ctx) => {
         currentStep = step as AppDeploymentSteps;
       }
     },
-    onComplete: async () => {
-      await syncJson.edit.dispose();
+    onComplete: () => {
+      subscription.unsubscribe();
     },
   });
 };


### PR DESCRIPTION
To fix the `ggt deploy` hanging issue in #1576, we started disposing of the `graphql-ws` client using the `onComplete` callback. While this resolved the hang, it caused another problem: after confirming a user wants to proceed with deployment, `ggt deploy` would immediately exit.

This is because after a user confirms they want to continue, `ggt deploy` unsubscribes and re-subscribes with different arguments. The unsubscribe was disposing of the `graphql-ws` client, so the subsequent re-subscribe would no-op, causing `ggt` to exit.

Rather than disposing the client, this PR changes `ggt deploy` to unsubscribe in the `onComplete` callback. This solved both issues because:
1. We're not calling dispose on the client anymore so re-subscribing will always work
2. I realized that we were unsubscribing before we received the "complete" message from the server, which was causing the `ggt deploy` hanging issue in the first place, so unsubscribing in the `onComplete` callback fixes that too