### PR TITLE
Clear callback queue when caller unsubscribes

### DIFF
--- a/src/services/app/client.ts
+++ b/src/services/app/client.ts
@@ -144,6 +144,7 @@ export class Client {
     return () => {
       ctx.log.trace("unsubscribing from graphql subscription");
       removeConnectedListener();
+      queue.clear();
       unsubscribe();
     };
   }


### PR DESCRIPTION
This **actually** fixes the "ggt deploy immediately exiting" bug that I thought I fixed in #1581...

Calling unsubscribing within the onComplete callback causes ggt to unsubscribe from the resubscription after confirming, causing ggt to immediately exit 🤦

This fixes that by clearing the queue of callbacks after unsubscribing the first time.