### PR TITLE
implements ggt side of data delete warning

### DIFF
--- a/.changeset/add-data-deleted-warning-on-deploy.md
+++ b/.changeset/add-data-deleted-warning-on-deploy.md
@@ -1,5 +1,5 @@
 ---
-"ggt": patch
+"ggt": minor
 ---
 
 `ggt deploy` will now show a deleted data warning when pushing changes to production that would cause data loss.

--- a/.changeset/add-data-deleted-warning-on-deploy.md
+++ b/.changeset/add-data-deleted-warning-on-deploy.md
@@ -1,0 +1,7 @@
+---
+"ggt": patch
+---
+
+`ggt deploy` will now show a deleted data warning when pushing changes to production that would cause data loss.
+
+<img width="654" alt="image" src="https://github.com/user-attachments/assets/52b45cc7-54fb-480e-ad73-2d80fea3d4eb">

--- a/spec/commands/__snapshots__/root.spec.ts.snap
+++ b/spec/commands/__snapshots__/root.spec.ts.snap
@@ -97,6 +97,7 @@ Options
       --allow-different-directory    Deploys from any local directory with existing files, even if the ".gadget/sync.json" file is missing
       --allow-different-app          Deploys a different app using the --app command, instead of the one specified in the “.gadget/sync.json” file
       --allow-problems               Deploys despite any existing issues found in the app (gelly errors, typescript errors etc.)
+      --allow-data-delete            Deploys even if it results in the deletion of data in production
       --allow-charges                Deploys even if it results in additional charges to your plan
 
 Examples
@@ -122,6 +123,7 @@ Options
       --allow-different-directory    Deploys from any local directory with existing files, even if the ".gadget/sync.json" file is missing
       --allow-different-app          Deploys a different app using the --app command, instead of the one specified in the “.gadget/sync.json” file
       --allow-problems               Deploys despite any existing issues found in the app (gelly errors, typescript errors etc.)
+      --allow-data-delete            Deploys even if it results in the deletion of data in production
       --allow-charges                Deploys even if it results in additional charges to your plan
 
 Examples

--- a/src/__generated__/edit.graphql
+++ b/src/__generated__/edit.graphql
@@ -149,13 +149,13 @@ type DeleteAppStatusResult {
   success: Boolean!
 }
 
-type DeletedModelField {
+type DeletedModelFieldsSummary {
   fields: [String!]!
   modelIdentifier: String!
 }
 
 type DeletedModelsAndFields {
-  deletedModelFields: [DeletedModelField!]!
+  deletedModelFields: [DeletedModelFieldsSummary!]!
   deletedModels: [String!]!
 }
 

--- a/src/__generated__/edit.graphql
+++ b/src/__generated__/edit.graphql
@@ -149,6 +149,16 @@ type DeleteAppStatusResult {
   success: Boolean!
 }
 
+type DeletedModelField {
+  fields: [String!]!
+  modelIdentifier: String!
+}
+
+type DeletedModelsAndFields {
+  deletedModelFields: [DeletedModelField!]!
+  deletedModels: [String!]!
+}
+
 type EnableFrontendResult {
   reason: String
   success: Boolean!
@@ -428,6 +438,7 @@ type PublishStatus {
 }
 
 type PublishStatusState {
+  deletedModelsAndFields: DeletedModelsAndFields
   issues: [PublishIssue!]!
   progress: String!
   publishStarted: Boolean!
@@ -493,7 +504,7 @@ type Subscription {
   logsSearch(limit: Int, query: String!, start: DateTime): LogSearchResult!
   migrateGadgetV1Status: MigrateGadgetV1Status
   openBackgroundActions: Int!
-  publishStatus(allowCharges: Boolean, force: Boolean, localFilesVersion: String!): PublishStatusState
+  publishStatus(allowCharges: Boolean, allowDeletedData: Boolean, force: Boolean, localFilesVersion: String!): PublishStatusState
   remoteFileSyncEvents(encoding: FileSyncEncoding, localFilesVersion: String!): RemoteFileSyncEvents!
   reportClientPresence(clientID: EnvironmentTreeClientId!): Boolean
   typesManifestStream: TypesManifest!

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -2,7 +2,7 @@
  * ======================================================
  * THIS IS A GENERATED FILE! DO NOT EDIT IT MANUALLY!
  *
- * You can regenerate it by running `pnpm run generate-graphql`.
+ * You can regenerate it by running `npm run generate-graphql`.
  * ======================================================
  */
 
@@ -177,6 +177,18 @@ export type DeleteAppStatusResult = {
   isNotCreator?: Maybe<Scalars['Boolean']['output']>;
   isNotOwner?: Maybe<Scalars['Boolean']['output']>;
   success: Scalars['Boolean']['output'];
+};
+
+export type DeletedModelField = {
+  __typename?: 'DeletedModelField';
+  fields: Array<Scalars['String']['output']>;
+  modelIdentifier: Scalars['String']['output'];
+};
+
+export type DeletedModelsAndFields = {
+  __typename?: 'DeletedModelsAndFields';
+  deletedModelFields: Array<DeletedModelField>;
+  deletedModels: Array<Scalars['String']['output']>;
 };
 
 /** One upload target to use for the Direct Upload style of sending files to Gadget */
@@ -500,7 +512,7 @@ export type GadgetGlobalAction = {
   apiIdentifier: Scalars['String']['output'];
   examples?: Maybe<GadgetGlobalActionGraphQlType>;
   name: Scalars['String']['output'];
-  namespace: Array<Scalars['String']['output']>;
+  namespace?: Maybe<Array<Scalars['String']['output']>>;
   requiresInput: Scalars['Boolean']['output'];
   triggers?: Maybe<Array<GadgetTrigger>>;
 };
@@ -1208,6 +1220,7 @@ export type PublishStatus = {
 
 export type PublishStatusState = {
   __typename?: 'PublishStatusState';
+  deletedModelsAndFields?: Maybe<DeletedModelsAndFields>;
   issues: Array<PublishIssue>;
   progress: Scalars['String']['output'];
   publishStarted: Scalars['Boolean']['output'];
@@ -1435,6 +1448,7 @@ export type SubscriptionLogsSearchArgs = {
 
 export type SubscriptionPublishStatusArgs = {
   allowCharges?: InputMaybe<Scalars['Boolean']['input']>;
+  allowDeletedData?: InputMaybe<Scalars['Boolean']['input']>;
   force?: InputMaybe<Scalars['Boolean']['input']>;
   localFilesVersion: Scalars['String']['input'];
 };
@@ -1536,7 +1550,7 @@ export type GadgetMetaModelsQuery = { __typename?: 'Query', gadgetMeta: { __type
 export type GadgetMetaGlobalActionsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GadgetMetaGlobalActionsQuery = { __typename?: 'Query', gadgetMeta: { __typename?: 'GadgetApplicationMeta', globalActions: Array<{ __typename?: 'GadgetGlobalAction', apiIdentifier: string, namespace: Array<string> }> } };
+export type GadgetMetaGlobalActionsQuery = { __typename?: 'Query', gadgetMeta: { __typename?: 'GadgetApplicationMeta', globalActions: Array<{ __typename?: 'GadgetGlobalAction', apiIdentifier: string, namespace?: Array<string> | null }> } };
 
 export type RemoteFileSyncEventsSubscriptionVariables = Exact<{
   localFilesVersion: Scalars['String']['input'];
@@ -1584,10 +1598,11 @@ export type PublishStatusSubscriptionVariables = Exact<{
   localFilesVersion: Scalars['String']['input'];
   force?: InputMaybe<Scalars['Boolean']['input']>;
   allowCharges?: InputMaybe<Scalars['Boolean']['input']>;
+  allowDeletedData?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 
-export type PublishStatusSubscription = { __typename?: 'Subscription', publishStatus?: { __typename?: 'PublishStatusState', publishStarted: boolean, remoteFilesVersion: string, progress: string, issues: Array<{ __typename?: 'PublishIssue', severity: string, message: string, node?: { __typename?: 'PublishIssueNode', type: string, key: string, apiIdentifier?: string | null, name?: string | null, fieldType?: string | null, parentKey?: string | null, parentApiIdentifier?: string | null } | null, nodeLabels?: Array<{ __typename?: 'PublishIssueNodeLabel', type?: string | null, identifier?: string | null } | null> | null }>, status?: { __typename?: 'PublishStatus', code?: string | null, message?: string | null, output?: string | null } | null } | null };
+export type PublishStatusSubscription = { __typename?: 'Subscription', publishStatus?: { __typename?: 'PublishStatusState', publishStarted: boolean, remoteFilesVersion: string, progress: string, issues: Array<{ __typename?: 'PublishIssue', severity: string, message: string, node?: { __typename?: 'PublishIssueNode', type: string, key: string, apiIdentifier?: string | null, name?: string | null, fieldType?: string | null, parentKey?: string | null, parentApiIdentifier?: string | null } | null, nodeLabels?: Array<{ __typename?: 'PublishIssueNodeLabel', type?: string | null, identifier?: string | null } | null> | null }>, deletedModelsAndFields?: { __typename?: 'DeletedModelsAndFields', deletedModels: Array<string>, deletedModelFields: Array<{ __typename?: 'DeletedModelField', modelIdentifier: string, fields: Array<string> }> } | null, status?: { __typename?: 'PublishStatus', code?: string | null, message?: string | null, output?: string | null } | null } | null };
 
 export type CreateModelMutationVariables = Exact<{
   path: Scalars['String']['input'];

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -179,15 +179,15 @@ export type DeleteAppStatusResult = {
   success: Scalars['Boolean']['output'];
 };
 
-export type DeletedModelField = {
-  __typename?: 'DeletedModelField';
+export type DeletedModelFieldsSummary = {
+  __typename?: 'DeletedModelFieldsSummary';
   fields: Array<Scalars['String']['output']>;
   modelIdentifier: Scalars['String']['output'];
 };
 
 export type DeletedModelsAndFields = {
   __typename?: 'DeletedModelsAndFields';
-  deletedModelFields: Array<DeletedModelField>;
+  deletedModelFields: Array<DeletedModelFieldsSummary>;
   deletedModels: Array<Scalars['String']['output']>;
 };
 
@@ -1602,7 +1602,7 @@ export type PublishStatusSubscriptionVariables = Exact<{
 }>;
 
 
-export type PublishStatusSubscription = { __typename?: 'Subscription', publishStatus?: { __typename?: 'PublishStatusState', publishStarted: boolean, remoteFilesVersion: string, progress: string, issues: Array<{ __typename?: 'PublishIssue', severity: string, message: string, node?: { __typename?: 'PublishIssueNode', type: string, key: string, apiIdentifier?: string | null, name?: string | null, fieldType?: string | null, parentKey?: string | null, parentApiIdentifier?: string | null } | null, nodeLabels?: Array<{ __typename?: 'PublishIssueNodeLabel', type?: string | null, identifier?: string | null } | null> | null }>, deletedModelsAndFields?: { __typename?: 'DeletedModelsAndFields', deletedModels: Array<string>, deletedModelFields: Array<{ __typename?: 'DeletedModelField', modelIdentifier: string, fields: Array<string> }> } | null, status?: { __typename?: 'PublishStatus', code?: string | null, message?: string | null, output?: string | null } | null } | null };
+export type PublishStatusSubscription = { __typename?: 'Subscription', publishStatus?: { __typename?: 'PublishStatusState', publishStarted: boolean, remoteFilesVersion: string, progress: string, issues: Array<{ __typename?: 'PublishIssue', severity: string, message: string, node?: { __typename?: 'PublishIssueNode', type: string, key: string, apiIdentifier?: string | null, name?: string | null, fieldType?: string | null, parentKey?: string | null, parentApiIdentifier?: string | null } | null, nodeLabels?: Array<{ __typename?: 'PublishIssueNodeLabel', type?: string | null, identifier?: string | null } | null> | null }>, deletedModelsAndFields?: { __typename?: 'DeletedModelsAndFields', deletedModels: Array<string>, deletedModelFields: Array<{ __typename?: 'DeletedModelFieldsSummary', modelIdentifier: string, fields: Array<string> }> } | null, status?: { __typename?: 'PublishStatus', code?: string | null, message?: string | null, output?: string | null } | null } | null };
 
 export type CreateModelMutationVariables = Exact<{
   path: Scalars['String']['input'];

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -191,13 +191,13 @@ export const run: Run<DeployArgs> = async (ctx) => {
           const rows: { symbol: string; name: string; action: string; indent: number }[] = [];
 
           deletedModels.forEach((model: string) => {
-            rows.push({ symbol: deletedSymbol, name: chalk.red(model), action: deleted, indent: 0 });
+            rows.push({ symbol: deletedSymbol, name: chalk.redBright(model), action: deleted, indent: 0 });
           });
 
           deletedModelFields.forEach(({ modelIdentifier, fields }) => {
-            rows.push({ symbol: updatedSymbol, name: chalk.blue(modelIdentifier), action: updated, indent: 0 });
+            rows.push({ symbol: updatedSymbol, name: chalk.blueBright(modelIdentifier), action: updated, indent: 0 });
             fields.forEach((field) => {
-              rows.push({ symbol: deletedSymbol, name: chalk.red(field), action: deleted, indent: 2 });
+              rows.push({ symbol: deletedSymbol, name: chalk.redBright(field), action: deleted, indent: 2 });
             });
           });
 

--- a/src/services/app/edit/operation.ts
+++ b/src/services/app/edit/operation.ts
@@ -167,8 +167,8 @@ export const FILE_SYNC_COMPARISON_HASHES_QUERY = sprint(/* GraphQL */ `
 export type FILE_SYNC_COMPARISON_HASHES_QUERY = typeof FILE_SYNC_COMPARISON_HASHES_QUERY;
 
 export const PUBLISH_STATUS_SUBSCRIPTION = sprint(/* GraphQL */ `
-  subscription PublishStatus($localFilesVersion: String!, $force: Boolean, $allowCharges: Boolean) {
-    publishStatus(localFilesVersion: $localFilesVersion, force: $force, allowCharges: $allowCharges) {
+  subscription PublishStatus($localFilesVersion: String!, $force: Boolean, $allowCharges: Boolean, $allowDeletedData: Boolean) {
+    publishStatus(localFilesVersion: $localFilesVersion, force: $force, allowCharges: $allowCharges, allowDeletedData: $allowDeletedData) {
       publishStarted
       remoteFilesVersion
       progress
@@ -187,6 +187,13 @@ export const PUBLISH_STATUS_SUBSCRIPTION = sprint(/* GraphQL */ `
         nodeLabels {
           type
           identifier
+        }
+      }
+      deletedModelsAndFields {
+        deletedModels
+        deletedModelFields {
+          modelIdentifier
+          fields
         }
       }
       status {

--- a/src/services/filesync/changes.ts
+++ b/src/services/filesync/changes.ts
@@ -50,10 +50,10 @@ export type PrintChangesOptions = Partial<SprintTableOptions> & {
   limit?: number;
 };
 
-const createdSymbol = chalk.greenBright("+");
-const updatedSymbol = chalk.blueBright("±");
-const deletedSymbol = chalk.redBright("-");
-const renameSymbol = chalk.yellowBright("→");
+export const createdSymbol = chalk.greenBright("+");
+export const updatedSymbol = chalk.blueBright("±");
+export const deletedSymbol = chalk.redBright("-");
+export const renameSymbol = chalk.yellowBright("→");
 
 /**
  * Prints the changes to the console.

--- a/src/services/output/confirm.ts
+++ b/src/services/output/confirm.ts
@@ -175,7 +175,7 @@ export class Confirm extends Prompt {
     output.updatePrompt(
       sprintln({
         ...this.options,
-        content: `${this.options.content} ${this.defaultValue ? "[Y/n] " : "[y/N] "}`,
+        content: `${this.options.content} ${this.defaultValue ? chalk.blueBright("[Y/n] ") : chalk.blueBright("[y/N] ")}`,
       }),
     );
   }


### PR DESCRIPTION
Implements the GGT side of https://linear.app/gadget-dev/issue/GGT-6590/hard-deleting-models-or-fields-needs-to-warn-on-deploy

Adds a new `--allow-data-delete` flag to the deploy command to force/acknowledge deploys deleting data as a result of modifying fields/removing models.