### PR TITLE
Drop support for ggt v0.4

### DIFF
--- a/.changeset/drop-v04-support.md
+++ b/.changeset/drop-v04-support.md
@@ -1,0 +1,7 @@
+---
+ggt: "minor"
+---
+
+Dropped support for downgrading to ggt v0.4.x
+
+ggt v1.1.x will no longer output a `.gadget/sync.json` file that is compatible with ggt v0.4.x. This means local directories that are synced with ggt v1.1.x will no longer be able to be synced with ggt v0.4.x. This change was made to simplify and reduce the complexity of the codebase.

--- a/spec/__support__/filesync.ts
+++ b/spec/__support__/filesync.ts
@@ -28,7 +28,7 @@ import { isEqualHashes } from "../../src/services/filesync/hashes.js";
 import { SyncJson, type SyncJsonArgs, type SyncJsonState } from "../../src/services/filesync/sync-json.js";
 import { noop } from "../../src/services/util/function.js";
 import { isNil } from "../../src/services/util/is.js";
-import { defaults, omit } from "../../src/services/util/object.js";
+import { defaults } from "../../src/services/util/object.js";
 import { PromiseSignal } from "../../src/services/util/promise.js";
 import type { PartialExcept } from "../../src/services/util/types.js";
 import { testApp } from "./app.js";
@@ -512,9 +512,8 @@ export const makeSyncScenario = async <Args extends SyncJsonArgs = DevArgs>({
             throw error;
           }
 
-          // omit mtime from the snapshot
-          const withoutMtime = omit(JSON.parse(local[".gadget/sync.json"]!), ["mtime"]);
-          local[".gadget/sync.json"] = JSON.stringify(withoutMtime);
+          // format .gadget/sync.json on a single line so inline snapshots are easier to read
+          local[".gadget/sync.json"] = JSON.stringify(JSON.parse(local[".gadget/sync.json"]!));
 
           return {
             localDir: local,
@@ -581,15 +580,7 @@ export const makeFile = (options: PartialExcept<File, "path">): File => {
 
 export const expectSyncJson = (filesync: FileSync, expected: Partial<SyncJsonState> = {}): string => {
   expect(filesync.syncJson.state).toMatchObject(expected);
-  return prettyJSON({
-    ...filesync.syncJson.state,
-
-    // deprecated
-    app: filesync.syncJson.app.slug,
-    filesVersion: String(filesync.syncJson.filesVersion),
-    // @ts-expect-error - mtime is private
-    mtime: filesync.syncJson._mtime,
-  });
+  return prettyJSON(filesync.syncJson.state);
 };
 
 export const expectPublishVariables = (expected: MutationPublishFileSyncEventsArgs): ZodSchema<MutationPublishFileSyncEventsArgs> => {

--- a/spec/commands/dev.spec.ts
+++ b/spec/commands/dev.spec.ts
@@ -79,7 +79,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
             "file.txt": "file v2",
           },
         }
@@ -115,7 +115,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
             "file.txt": "file v3",
           },
         }
@@ -155,7 +155,7 @@ describe("dev", () => {
             ".gadget/": "",
             ".gadget/backup/": "",
             ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"4"}},"app":"test","filesVersion":"4"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"4"}}}",
           },
         }
       `);
@@ -199,7 +199,7 @@ describe("dev", () => {
             ".gadget/": "",
             ".gadget/backup/": "",
             ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"5"}},"app":"test","filesVersion":"5"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"5"}}}",
             "directory/": "",
           },
         }
@@ -247,7 +247,7 @@ describe("dev", () => {
             ".gadget/backup/": "",
             ".gadget/backup/directory/": "",
             ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"6"}},"app":"test","filesVersion":"6"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"6"}}}",
           },
         }
       `);
@@ -318,7 +318,7 @@ describe("dev", () => {
             ".gadget/backup/": "",
             ".gadget/backup/directory/": "",
             ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}},"app":"test","filesVersion":"7"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}}}",
             "file1.txt": "file1.txt",
             "file10.txt": "file10.txt",
             "file2.txt": "file2.txt",
@@ -442,7 +442,7 @@ describe("dev", () => {
             ".gadget/backup/": "",
             ".gadget/backup/directory/": "",
             ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}},"app":"test","filesVersion":"7"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}}}",
             "file1.txt": "file1.txt",
             "file10.txt": "file10.txt",
             "file2.txt": "file2.txt",
@@ -573,7 +573,7 @@ describe("dev", () => {
             ".gadget/backup/": "",
             ".gadget/backup/directory/": "",
             ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}},"app":"test","filesVersion":"7"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}}}",
             "file.js": "file v2",
             "file1.txt": "file1.txt",
             "file10.txt": "file10.txt",
@@ -636,7 +636,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
             ".ignore": "**/tmp",
           },
         }
@@ -677,7 +677,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
             ".ignore": "**/tmp",
           },
         }
@@ -709,7 +709,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
             "file.txt": "file v2",
           },
         }
@@ -739,7 +739,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
             "file.txt": "file v3",
           },
         }
@@ -773,7 +773,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"4"}},"app":"test","filesVersion":"4"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"4"}}}",
             "renamed-file.txt": "file v3",
           },
         }
@@ -809,7 +809,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"5"}},"app":"test","filesVersion":"5"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"5"}}}",
           },
         }
       `);
@@ -849,7 +849,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"6"}},"app":"test","filesVersion":"6"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"6"}}}",
             "directory/": "",
           },
         }
@@ -894,7 +894,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}},"app":"test","filesVersion":"7"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}}}",
             "renamed-directory/": "",
           },
         }
@@ -941,7 +941,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"8"}},"app":"test","filesVersion":"8"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"8"}}}",
           },
         }
       `);
@@ -1019,7 +1019,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"9"}},"app":"test","filesVersion":"9"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"9"}}}",
             "file-01.txt": "file-01.txt",
             "file-02.txt": "file-02.txt",
             "file-03.txt": "file-03.txt",
@@ -1064,7 +1064,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
             "file.txt": "v10",
           },
         }
@@ -1135,7 +1135,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}},"app":"test","filesVersion":"1"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}}}",
             ".ignore": "**/tmp",
             "tmp/": "",
             "tmp/file-01.txt": "file-01.txt",
@@ -1180,7 +1180,7 @@ describe("dev", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
             ".ignore": "# watch it all",
           },
         }

--- a/spec/commands/pull.spec.ts
+++ b/spec/commands/pull.spec.ts
@@ -60,7 +60,7 @@ describe("pull", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}},"app":"test","filesVersion":"1"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}}}",
           },
         }
       `);
@@ -102,7 +102,7 @@ describe("pull", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
             "file1.txt": "file1.txt",
             "file10.txt": "file10.txt",
             "file2.txt": "file2.txt",
@@ -159,7 +159,7 @@ describe("pull", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}},"app":"test","filesVersion":"1"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}}}",
             ".ignore": "**/tmp",
           },
         }
@@ -192,7 +192,7 @@ describe("pull", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}},"app":"test","filesVersion":"1"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}}}",
             ".ignore": "**/tmp",
           },
         }

--- a/spec/commands/push.spec.ts
+++ b/spec/commands/push.spec.ts
@@ -33,7 +33,7 @@ describe("push", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}},"app":"test","filesVersion":"1"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}}}",
           },
         }
       `);
@@ -81,7 +81,7 @@ describe("push", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
             "file1.txt": "file1.txt",
             "file10.txt": "file10.txt",
             "file2.txt": "file2.txt",
@@ -124,7 +124,7 @@ describe("push", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}},"app":"test","filesVersion":"1"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}}}",
             ".ignore": "**/tmp",
           },
         }
@@ -152,7 +152,7 @@ describe("push", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}},"app":"test","filesVersion":"1"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}}}",
             ".ignore": "**/tmp",
             "tmp/": "",
             "tmp/file1.txt": "file1.txt",

--- a/spec/services/filesync/filesync.spec.ts
+++ b/spec/services/filesync/filesync.spec.ts
@@ -806,7 +806,7 @@ describe("FileSync.mergeChangesWithEnvironment", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
           "gadget.txt": "// gadget",
           "local.txt": "// local",
         },
@@ -872,7 +872,7 @@ describe("FileSync.mergeChangesWithEnvironment", () => {
         "localDir": {
           ".gadget/": "",
           ".gadget/client.js": "// client",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"4"}},"app":"test","filesVersion":"4"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"4"}}}",
           "gadget.txt": "// gadget",
           "local.txt": "// local",
         },
@@ -913,7 +913,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}},"app":"test","filesVersion":"1"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}}}",
           "foo.js": "// foo",
         },
       }
@@ -956,7 +956,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}},"app":"test","filesVersion":"1"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}}}",
           ".ignore": "foo.js",
           "foo.js": "// foo (local)",
         },
@@ -1010,7 +1010,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
           "foo.js": "// foo",
           "gadget-file.js": "// gadget",
           "local-file.js": "// local",
@@ -1050,7 +1050,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}},"app":"test","filesVersion":"1"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}}}",
           "foo.js": "foo (local)",
         },
       }
@@ -1096,7 +1096,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
           "foo.js": "// foo (local)",
         },
       }
@@ -1143,7 +1143,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
           "foo.js": "// foo (local)",
         },
       }
@@ -1198,7 +1198,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
           "foo.js": "// foo (local)",
           "gadget-file.js": "// gadget",
           "local-file.js": "// local",
@@ -1254,7 +1254,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
           "foo.js": "// foo (local)",
           "gadget-file.js": "// gadget",
           "local-file.js": "// local",
@@ -1300,7 +1300,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
           "foo.js": "// foo (gadget)",
         },
       }
@@ -1343,7 +1343,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
           "foo.js": "// foo (gadget)",
         },
       }
@@ -1398,7 +1398,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
           "foo.js": "// foo (gadget)",
           "gadget-file.js": "// gadget",
           "local-file.js": "// local",
@@ -1455,7 +1455,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
           "foo.js": "// foo (gadget)",
           "gadget-file.js": "// gadget",
           "local-file.js": "// local",
@@ -1511,7 +1511,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
           "foo.js": "// foo (gadget)",
           "gadget-file.js": "// gadget",
           "local-file.js": "// local",
@@ -1556,7 +1556,7 @@ describe("FileSync.sync", () => {
         "localDir": {
           ".gadget/": "",
           ".gadget/client.js": "// client (gadget)",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
         },
       }
     `);
@@ -1611,7 +1611,7 @@ describe("FileSync.sync", () => {
         "localDir": {
           ".gadget/": "",
           ".gadget/client.js": "// client (gadget)",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
           "foo.js": "// foo (local)",
         },
       }
@@ -1648,7 +1648,7 @@ describe("FileSync.sync", () => {
         "localDir": {
           ".gadget/": "",
           ".gadget/client.js": "// client",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}},"app":"test","filesVersion":"1"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"1"}}}",
         },
       }
     `);
@@ -1708,7 +1708,7 @@ describe("FileSync.sync", () => {
           ".gadget/": "",
           ".gadget/client.js": "// client",
           ".gadget/server.js": "// server",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
           "gadget-file.js": "// gadget",
           "local-file.js": "// local",
         },
@@ -1762,7 +1762,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
           "gadget.txt": "// gadget",
           "local.txt": "// local",
         },
@@ -1879,7 +1879,7 @@ describe("FileSync.sync", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"cool-environment-development","environments":{"development":{"filesVersion":"1"},"cool-environment-development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+          ".gadget/sync.json": "{"application":"test","environment":"cool-environment-development","environments":{"development":{"filesVersion":"1"},"cool-environment-development":{"filesVersion":"3"}}}",
           "foo.js": "// foo",
           "gadget-file.js": "// gadget",
           "local-file.js": "// local",
@@ -1920,7 +1920,7 @@ describe("FileSync.push", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
             "local-file.js": "// local",
           },
         }
@@ -1966,7 +1966,7 @@ describe("FileSync.push", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
             "local-file.js": "// local",
           },
         }
@@ -2012,7 +2012,7 @@ describe("FileSync.push", () => {
           },
           "localDir": {
             ".gadget/": "",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
             "local-file.js": "// local",
           },
         }
@@ -2065,7 +2065,7 @@ describe("FileSync.push", () => {
           "localDir": {
             ".gadget/": "",
             ".gadget/client.js": "// client",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}},"app":"test","filesVersion":"3"}",
+            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"3"}}}",
             "local-file.js": "// local",
           },
         }
@@ -2111,7 +2111,7 @@ describe("FileSync.pull", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
           "gadget-file.js": "// gadget",
         },
       }
@@ -2155,7 +2155,7 @@ describe("FileSync.pull", () => {
           ".gadget/": "",
           ".gadget/backup/": "",
           ".gadget/backup/local-file.js": "// local",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
           "gadget-file.js": "// gadget",
         },
       }
@@ -2199,7 +2199,7 @@ describe("FileSync.pull", () => {
           ".gadget/": "",
           ".gadget/backup/": "",
           ".gadget/backup/local-file.js": "// local",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
           "gadget-file.js": "// gadget",
         },
       }
@@ -2242,7 +2242,7 @@ describe("FileSync.pull", () => {
           ".gadget/backup/": "",
           ".gadget/backup/.gadget/": "",
           ".gadget/backup/.gadget/local.js": "// .gadget/local",
-          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}},"app":"test","filesVersion":"2"}",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
           "gadget-file.js": "// gadget",
         },
       }

--- a/spec/services/filesync/sync-json.spec.ts
+++ b/spec/services/filesync/sync-json.spec.ts
@@ -7,7 +7,7 @@ import { ArgError } from "../../../src/services/command/arg.js";
 import type { Context } from "../../../src/services/command/context.js";
 import { Directory } from "../../../src/services/filesync/directory.js";
 import { UnknownDirectoryError } from "../../../src/services/filesync/error.js";
-import { SyncJson, SyncJsonArgs, type AnySyncJsonState, type SyncJsonStateV05 } from "../../../src/services/filesync/sync-json.js";
+import { SyncJson, SyncJsonArgs, type AnySyncJsonState } from "../../../src/services/filesync/sync-json.js";
 import { nockTestApps, testApp, testApp2, testAppWith2Environments } from "../../__support__/app.js";
 import { makeContext } from "../../__support__/context.js";
 import { expectError } from "../../__support__/error.js";
@@ -63,7 +63,7 @@ describe("SyncJson.loadOrInit", () => {
       environments: {
         development: { filesVersion: "77" },
       },
-    } as SyncJsonStateV05);
+    });
   });
 
   it("uses default state if .gadget/sync.json does not exist and the directory is empty", async () => {


### PR DESCRIPTION
We changed the structure of `.gadget/sync.json` when we shipped ggt v1 to support multiple environments. However, we still stored the old structure within the new structure in case users had to downgrade or had multiple versions of ggt installed.

**Before**
```json
{
  "app": "some-app",
  "filesVersion": "456",
  "mtime": 1711134057476
}
```

**After**
```json5
{
  // new structure that v1 uses
  "application": "some-app",
  "environment": "development",
  "environments": {
    "development": {
      "filesVersion": "456"
    }
  },

  // old structure that v0.4 uses
  "app": "some-app",
  "filesVersion": "456",
  "mtime": 1711134057476
}
```

Now that ggt v1 has been out for 6 months now, let's stop saving the old structure within `.gadget/sync.json` so we can clean up old code that shouldn't be used anymore.

I didn't remove the code that parses the old `.gadget/sync.json` and converts it to the new one, so old directories that were synced with ggt v0.4 can still be synced with ggt v1. They just won't be able to sync with ggt v0.4 again.