### PR TITLE
Decouple args from context

### DIFF
--- a/scripts/generate-readme.ts
+++ b/scripts/generate-readme.ts
@@ -6,11 +6,11 @@ import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import remarkToc from "remark-toc";
 import { dedent } from "ts-dedent";
-import { args, usage } from "../src/commands/root.js";
+import { usage } from "../src/commands/root.js";
 import { Commands, importCommand } from "../src/services/command/command.js";
 import { Context } from "../src/services/command/context.js";
 
-const ctx = Context.init({ name: "readme", parse: args, argv: ["-h"] });
+const ctx = Context.init({ name: "readme" });
 let readme = await fs.readFile("README.md", "utf8");
 
 readme = readme.replace(

--- a/spec/__support__/arg.ts
+++ b/spec/__support__/arg.ts
@@ -1,0 +1,23 @@
+import { expect } from "vitest";
+import * as root from "../../src/commands/root.js";
+import { parseArgs, type ArgsDefinition, type ArgsDefinitionResult } from "../../src/services/command/arg.js";
+import { Commands, setCurrentCommand, type Command } from "../../src/services/command/command.js";
+import { testCtx } from "./context.js";
+
+export const makeRootArgs = (...argv: string[]): root.RootArgsResult => {
+  return parseArgs(root.args, { argv, permissive: true });
+};
+
+export const makeArgs = <Args extends ArgsDefinition>(args: Args, ...argv: string[]): ArgsDefinitionResult<Args> => {
+  const rootArgs = makeRootArgs(...argv);
+
+  // replicate the root command's behavior of shifting the command name
+  const commandName = rootArgs._.shift() as Command | undefined;
+  if (commandName) {
+    // ensure the command was valid
+    expect(Commands).toContain(commandName);
+    setCurrentCommand(testCtx, commandName);
+  }
+
+  return parseArgs(args, { argv: rootArgs._ });
+};

--- a/spec/__support__/context.ts
+++ b/spec/__support__/context.ts
@@ -1,14 +1,8 @@
-import { beforeEach, expect } from "vitest";
-import { args } from "../../src/commands/root.js";
-import type { ArgsDefinition } from "../../src/services/command/arg.js";
-import { Commands, setCurrentCommand, type Command } from "../../src/services/command/command.js";
+import { beforeEach } from "vitest";
 import { Context } from "../../src/services/command/context.js";
 
 /**
- * The current test's context.
- *
- * All contexts made by {@linkcode makeRootContext} and
- * {@linkcode makeContext} are children of this context.
+ * A {@linkcode Context} that is set up before each test.
  */
 export let testCtx: Context;
 
@@ -22,42 +16,4 @@ export const mockContext = (): void => {
       testCtx.abort();
     };
   });
-};
-
-/**
- * Makes a root context the same way the root command does.
- */
-export const makeRootContext = (): Context => {
-  return testCtx.child({
-    name: "root",
-    parse: args,
-    argv: process.argv.slice(2),
-    permissive: true,
-  });
-};
-
-/**
- * Makes a context the same way the root command would before passing it
- * to a subcommand.
- */
-// TODO: make this take an AvailableCommand and use it to type which `parse` must be passed
-export const makeContext = <Args extends ArgsDefinition>({
-  parse = {} as Args,
-  argv,
-}: { parse?: Args; argv?: string[] } = {}): Context<Args> => {
-  if (argv) {
-    process.argv = ["node", "/some/path/to/ggt.js", ...argv];
-  }
-
-  const ctx = makeRootContext();
-
-  // replicate the root command's behavior of shifting the command name
-  const commandName = ctx.args._.shift() as Command | undefined;
-  if (commandName) {
-    // ensure the command was valid
-    expect(Commands).toContain(commandName);
-    setCurrentCommand(ctx, commandName);
-  }
-
-  return ctx.child({ name: commandName, parse });
 };

--- a/spec/commands/add.spec.ts
+++ b/spec/commands/add.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { run as addCommand, args } from "../../src/commands/add.js";
+import * as add from "../../src/commands/add.js";
 import { GADGET_GLOBAL_ACTIONS_QUERY, GADGET_META_MODELS_QUERY } from "../../src/services/app/api/operation.js";
 import {
   CREATE_ACTION_MUTATION,
@@ -8,7 +8,8 @@ import {
   CREATE_ROUTE_MUTATION,
 } from "../../src/services/app/edit/operation.js";
 import { ArgError } from "../../src/services/command/arg.js";
-import { makeContext } from "../__support__/context.js";
+import { makeArgs } from "../__support__/arg.js";
+import { testCtx } from "../__support__/context.js";
 import { expectError } from "../__support__/error.js";
 import { makeSyncScenario } from "../__support__/filesync.js";
 import { nockApiResponse, nockEditResponse } from "../__support__/graphql.js";
@@ -28,9 +29,7 @@ describe("add", () => {
           expectVariables: { path: "modelA", fields: [] },
         });
 
-        const ctx = makeContext({ parse: args, argv: ["add", "model", "modelA"] });
-
-        await addCommand(ctx);
+        await add.run(testCtx, makeArgs(add.args, "add", "model", "modelA"));
       });
 
       it("can add a model with fields", async () => {
@@ -46,15 +45,11 @@ describe("add", () => {
           },
         });
 
-        const ctx = makeContext({ parse: args, argv: ["add", "model", "modelA", "newField:string", "newField2:boolean"] });
-
-        await addCommand(ctx);
+        await add.run(testCtx, makeArgs(add.args, "add", "model", "modelA", "newField:string", "newField2:boolean"));
       });
 
       it("requires a model path", async () => {
-        const ctx = makeContext({ parse: args, argv: ["add", "model"] });
-
-        const error = await expectError(() => addCommand(ctx));
+        const error = await expectError(() => add.run(testCtx, makeArgs(add.args, "add", "model")));
         expect(error).toBeInstanceOf(ArgError);
         expect(error.sprint()).toMatchInlineSnapshot(`
           "✘ Failed to add model, missing model path
@@ -65,9 +60,7 @@ describe("add", () => {
       });
 
       it.each(["field;string", "field:", ":", ""])('returns ArgErrors when field argument is "%s"', async (invalidFieldArgument) => {
-        const ctx = makeContext({ parse: args, argv: ["add", "model", "newModel", invalidFieldArgument] });
-
-        const error = await expectError(() => addCommand(ctx));
+        const error = await expectError(() => add.run(testCtx, makeArgs(add.args, "add", "model", "modelA", invalidFieldArgument)));
         expect(error).toBeInstanceOf(ArgError);
         expect(error.sprint()).toContain("is not a valid field definition");
       });
@@ -84,15 +77,11 @@ describe("add", () => {
           },
         });
 
-        const ctx = makeContext({ parse: args, argv: ["add", "field", "modelA/newField:string"] });
-
-        await addCommand(ctx);
+        await add.run(testCtx, makeArgs(add.args, "add", "field", "modelA/newField:string"));
       });
 
       it("returns an ArgError if there's no input", async () => {
-        const ctx = makeContext({ parse: args, argv: ["add", "field"] });
-
-        const error = await expectError(() => addCommand(ctx));
+        const error = await expectError(() => add.run(testCtx, makeArgs(add.args, "add", "field")));
         expect(error).toBeInstanceOf(ArgError);
         expect(error.sprint()).toMatchInlineSnapshot(`
           "✘ Failed to add field, invalid field path definition
@@ -103,17 +92,13 @@ describe("add", () => {
       });
 
       it.each(["user", "user/"])("returns missing field definition ArgError if the input is %s", async (partialInput) => {
-        const ctx = makeContext({ parse: args, argv: ["add", "field", partialInput] });
-
-        const error = await expectError(() => addCommand(ctx));
+        const error = await expectError(() => add.run(testCtx, makeArgs(add.args, "add", "field", partialInput)));
         expect(error).toBeInstanceOf(ArgError);
         expect(error.sprint()).toContain("Failed to add field, invalid field definition");
       });
 
       it.each(["user/field", "user/field:", "user/:"])("returns missing field type ArgError if the input is %s", async (partialInput) => {
-        const ctx = makeContext({ parse: args, argv: ["add", "field", partialInput] });
-
-        const error = await expectError(() => addCommand(ctx));
+        const error = await expectError(() => add.run(testCtx, makeArgs(add.args, "add", "field", partialInput)));
         expect(error).toBeInstanceOf(ArgError);
         expect(error.sprint()).toContain("is not a valid field definition");
       });
@@ -167,15 +152,11 @@ describe("add", () => {
           expectVariables: { path: "actionA" },
         });
 
-        const ctx = makeContext({ parse: args, argv: ["add", "action", "actionA"] });
-
-        await addCommand(ctx);
+        await add.run(testCtx, makeArgs(add.args, "add", "action", "actionA"));
       });
 
       it("requires an action name/path", async () => {
-        const ctx = makeContext({ parse: args, argv: ["add", "action"] });
-
-        const error = await expectError(() => addCommand(ctx));
+        const error = await expectError(() => add.run(testCtx, makeArgs(add.args, "add", "action")));
         expect(error).toBeInstanceOf(ArgError);
         expect(error.sprint()).toMatchInlineSnapshot(`
           "✘ Failed to add action, missing action path
@@ -195,15 +176,11 @@ describe("add", () => {
           expectVariables: { method: "GET", path: "routeA" },
         });
 
-        const ctx = makeContext({ parse: args, argv: ["add", "route", "GET", "routeA"] });
-
-        await addCommand(ctx);
+        await add.run(testCtx, makeArgs(add.args, "add", "route", "GET", "routeA"));
       });
 
       it("requires a method argument", async () => {
-        const ctx = makeContext({ parse: args, argv: ["add", "route"] });
-
-        const error = await expectError(() => addCommand(ctx));
+        const error = await expectError(() => add.run(testCtx, makeArgs(add.args, "add", "route")));
         expect(error).toBeInstanceOf(ArgError);
         expect(error.sprint()).toMatchInlineSnapshot(`
           "✘ Failed to add route, missing route method
@@ -214,9 +191,7 @@ describe("add", () => {
       });
 
       it("requires a route name", async () => {
-        const ctx = makeContext({ parse: args, argv: ["add", "route", "GET"] });
-
-        const error = await expectError(() => addCommand(ctx));
+        const error = await expectError(() => add.run(testCtx, makeArgs(add.args, "add", "route", "GET")));
         expect(error).toBeInstanceOf(ArgError);
         expect(error.sprint()).toMatchInlineSnapshot(`
           "✘ Failed to add route, missing route path

--- a/spec/commands/deploy.spec.ts
+++ b/spec/commands/deploy.spec.ts
@@ -1,13 +1,13 @@
 /* eslint-disable unicorn/no-null */
 /* eslint-disable no-irregular-whitespace */
-import { beforeEach, describe, it } from "vitest";
-import { makeContext } from "../../spec/__support__/context.js";
+import { describe, it } from "vitest";
 import { makeSyncScenario } from "../../spec/__support__/filesync.js";
 import { expectProcessExit } from "../../spec/__support__/process.js";
-import { args, run as deploy } from "../../src/commands/deploy.js";
+import * as deploy from "../../src/commands/deploy.js";
 import { PUBLISH_STATUS_SUBSCRIPTION } from "../../src/services/app/edit/operation.js";
 import { ClientError } from "../../src/services/app/error.js";
-import { type Context } from "../../src/services/command/context.js";
+import { makeArgs } from "../__support__/arg.js";
+import { testCtx } from "../__support__/context.js";
 import { makeMockEditSubscriptions } from "../__support__/graphql.js";
 import { expectStdout } from "../__support__/output.js";
 import { mockSystemTime } from "../__support__/time.js";
@@ -17,18 +17,12 @@ describe("deploy", () => {
   mockSystemTime();
 
   describeWithAuth(() => {
-    let ctx: Context<typeof args>;
-
-    beforeEach(() => {
-      ctx = makeContext({ parse: args });
-    });
-
     it("does not try to deploy if any problems were detected and displays the problems", async () => {
       await makeSyncScenario({ localFiles: { ".gadget/": "" } });
 
       const mockEditGraphQL = makeMockEditSubscriptions();
 
-      await deploy(ctx);
+      await deploy.run(testCtx, makeArgs(deploy.args));
 
       const publishStatus = mockEditGraphQL.expectSubscription(PUBLISH_STATUS_SUBSCRIPTION);
 
@@ -160,13 +154,11 @@ describe("deploy", () => {
     });
 
     it("deploys even if there are problems when --allow-problems is passed", async () => {
-      ctx = ctx.child({ overwrite: { "--allow-problems": true } });
-
-      await makeSyncScenario({ localFiles: { ".gadget/": "" }, ctx });
+      await makeSyncScenario({ localFiles: { ".gadget/": "" } });
 
       const mockEditGraphQL = makeMockEditSubscriptions();
 
-      await deploy(ctx);
+      await deploy.run(testCtx, makeArgs(deploy.args, "deploy", "--allow-problems"));
 
       const publishStatus = mockEditGraphQL.expectSubscription(PUBLISH_STATUS_SUBSCRIPTION);
 
@@ -334,7 +326,7 @@ describe("deploy", () => {
 
       const mockEditGraphQL = makeMockEditSubscriptions();
 
-      await deploy(ctx);
+      await deploy.run(testCtx, makeArgs(deploy.args));
 
       const publishStatus = mockEditGraphQL.expectSubscription(PUBLISH_STATUS_SUBSCRIPTION);
 
@@ -377,13 +369,11 @@ describe("deploy", () => {
     });
 
     it("deploys even if there are problems when --allow-data-delete is passed", async () => {
-      ctx = ctx.child({ overwrite: { "--allow-data-delete": true } });
-
-      await makeSyncScenario({ localFiles: { ".gadget/": "" }, ctx });
+      await makeSyncScenario({ localFiles: { ".gadget/": "" } });
 
       const mockEditGraphQL = makeMockEditSubscriptions();
 
-      await deploy(ctx);
+      await deploy.run(testCtx, makeArgs(deploy.args, "deploy", "--allow-data-delete"));
 
       const publishStatus = mockEditGraphQL.expectSubscription(PUBLISH_STATUS_SUBSCRIPTION);
 
@@ -549,7 +539,8 @@ describe("deploy", () => {
 
       const mockEditGraphQL = makeMockEditSubscriptions();
 
-      await deploy(ctx);
+      await deploy.run(testCtx, makeArgs(deploy.args));
+
       const publishStatus = mockEditGraphQL.expectSubscription(PUBLISH_STATUS_SUBSCRIPTION);
 
       await publishStatus.emitResponse({
@@ -712,7 +703,8 @@ describe("deploy", () => {
         },
       ]);
 
-      await deploy(ctx);
+      await deploy.run(testCtx, makeArgs(deploy.args));
+
       const publishStatus = mockEditGraphQL.expectSubscription(PUBLISH_STATUS_SUBSCRIPTION);
 
       await expectProcessExit(() => publishStatus.emitError(error), 1);
@@ -741,7 +733,8 @@ describe("deploy", () => {
         },
       ]);
 
-      await deploy(ctx);
+      await deploy.run(testCtx, makeArgs(deploy.args));
+
       const publishStatus = mockEditGraphQL.expectSubscription(PUBLISH_STATUS_SUBSCRIPTION);
 
       await expectProcessExit(() => publishStatus.emitError(error), 1);
@@ -775,7 +768,8 @@ describe("deploy", () => {
 
       const error = new ClientError(PUBLISH_STATUS_SUBSCRIPTION, cause);
 
-      await deploy(ctx);
+      await deploy.run(testCtx, makeArgs(deploy.args));
+
       const publishStatus = mockEditGraphQL.expectSubscription(PUBLISH_STATUS_SUBSCRIPTION);
 
       await publishStatus.emitResponse({
@@ -849,7 +843,8 @@ describe("deploy", () => {
 
       const mockEditGraphQL = makeMockEditSubscriptions();
 
-      await deploy(ctx);
+      await deploy.run(testCtx, makeArgs(deploy.args));
+
       const publishStatus = mockEditGraphQL.expectSubscription(PUBLISH_STATUS_SUBSCRIPTION);
 
       await publishStatus.emitResponse({
@@ -933,7 +928,7 @@ describe("deploy", () => {
 
       const mockEditGraphQL = makeMockEditSubscriptions();
 
-      await deploy(ctx);
+      await deploy.run(testCtx, makeArgs(deploy.args));
 
       const publishStatus = mockEditGraphQL.expectSubscription(PUBLISH_STATUS_SUBSCRIPTION);
 

--- a/spec/commands/list.spec.ts
+++ b/spec/commands/list.spec.ts
@@ -1,19 +1,16 @@
 import { beforeEach, describe, it } from "vitest";
-import { run as list } from "../../src/commands/list.js";
+import * as list from "../../src/commands/list.js";
 import * as app from "../../src/services/app/app.js";
-import { type Context } from "../../src/services/command/context.js";
 import { output } from "../../src/services/output/output.js";
 import { nockTestApps } from "../__support__/app.js";
-import { makeContext } from "../__support__/context.js";
+import { makeRootArgs } from "../__support__/arg.js";
+import { testCtx } from "../__support__/context.js";
 import { mock, mockOnce } from "../__support__/mock.js";
 import { expectStdout } from "../__support__/output.js";
 import { loginTestUser } from "../__support__/user.js";
 
 describe("list", () => {
-  let ctx: Context;
-
   beforeEach(() => {
-    ctx = makeContext();
     loginTestUser();
     nockTestApps();
   });
@@ -21,7 +18,7 @@ describe("list", () => {
   it("lists apps with tabs when output.isInteractive = true", async () => {
     mockOnce(output, "isInteractive", "get", () => true);
 
-    await list(ctx);
+    await list.run(testCtx, makeRootArgs());
 
     expectStdout().toMatchInlineSnapshot(`
       "first-test-team
@@ -41,7 +38,7 @@ describe("list", () => {
   it("lists apps with tabs when output.isInteractive = false", async () => {
     mockOnce(output, "isInteractive", "get", () => false);
 
-    await list(ctx);
+    await list.run(testCtx, makeRootArgs());
 
     expectStdout().toMatchInlineSnapshot(`
       "test	test.gadget.app
@@ -55,7 +52,7 @@ describe("list", () => {
   it("lists no apps if the user doesn't have any", async () => {
     mock(app, "getApps", () => []);
 
-    await list(ctx);
+    await list.run(testCtx, makeRootArgs());
 
     expectStdout().toMatchInlineSnapshot(`
       "It doesn't look like you have any applications.

--- a/spec/commands/logout.spec.ts
+++ b/spec/commands/logout.spec.ts
@@ -1,22 +1,16 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { run } from "../../src/commands/logout.js";
-import { type Context } from "../../src/services/command/context.js";
+import { describe, expect, it } from "vitest";
+import * as logout from "../../src/commands/logout.js";
 import { readSession, writeSession } from "../../src/services/user/session.js";
-import { makeContext, testCtx } from "../__support__/context.js";
+import { makeRootArgs } from "../__support__/arg.js";
+import { testCtx } from "../__support__/context.js";
 import { expectStdout } from "../__support__/output.js";
 
 describe("logout", () => {
-  let ctx: Context;
-
-  beforeEach(() => {
-    ctx = makeContext();
-  });
-
   it("deletes the session from disk", async () => {
     writeSession(testCtx, "test");
     expect(readSession(testCtx)).toBe("test");
 
-    await run(ctx);
+    await logout.run(testCtx, makeRootArgs());
 
     expect(readSession(testCtx)).toBeUndefined();
   });
@@ -24,7 +18,7 @@ describe("logout", () => {
   it("prints a message if the user is logged in", async () => {
     writeSession(testCtx, "test");
 
-    await run(ctx);
+    await logout.run(testCtx, makeRootArgs());
 
     expectStdout().toMatchInlineSnapshot(`
       "Goodbye
@@ -35,7 +29,7 @@ describe("logout", () => {
   it("prints a different message if the user is logged out", async () => {
     writeSession(testCtx, undefined);
 
-    await run(ctx);
+    await logout.run(testCtx, makeRootArgs());
 
     expectStdout().toMatchInlineSnapshot(`
       "You are not logged in

--- a/spec/commands/pull.spec.ts
+++ b/spec/commands/pull.spec.ts
@@ -1,18 +1,12 @@
-import { beforeEach, describe, it } from "vitest";
-import { args, run as pull, type PullArgs } from "../../src/commands/pull.js";
-import { type Context } from "../../src/services/command/context.js";
-import { makeContext } from "../__support__/context.js";
+import { describe, it } from "vitest";
+import * as pull from "../../src/commands/pull.js";
+import { makeArgs } from "../__support__/arg.js";
+import { testCtx } from "../__support__/context.js";
 import { makeSyncScenario } from "../__support__/filesync.js";
 import { describeWithAuth } from "../utils.js";
 
 describe("pull", () => {
-  let ctx: Context<PullArgs>;
-
   describeWithAuth(() => {
-    beforeEach(() => {
-      ctx = makeContext({ parse: args, argv: ["pull"] });
-    });
-
     it("writes changes from gadget to the local filesystem", async () => {
       const files = Array.from({ length: 10 }, (_, i) => `file${i + 1}.txt`);
 
@@ -65,7 +59,7 @@ describe("pull", () => {
         }
       `);
 
-      await pull(ctx);
+      await pull.run(testCtx, makeArgs(pull.args));
 
       await expectDirs().resolves.toMatchInlineSnapshot(`
         {
@@ -165,7 +159,7 @@ describe("pull", () => {
         }
       `);
 
-      await pull(ctx);
+      await pull.run(testCtx, makeArgs(pull.args));
 
       await expectDirs().resolves.toMatchInlineSnapshot(`
         {

--- a/spec/commands/push.spec.ts
+++ b/spec/commands/push.spec.ts
@@ -1,19 +1,13 @@
 import fs from "fs-extra";
-import { beforeEach, describe, it } from "vitest";
-import { args, run as push, type PushArgs } from "../../src/commands/push.js";
-import { type Context } from "../../src/services/command/context.js";
-import { makeContext } from "../__support__/context.js";
+import { describe, it } from "vitest";
+import * as push from "../../src/commands/push.js";
+import { makeArgs } from "../__support__/arg.js";
+import { testCtx } from "../__support__/context.js";
 import { makeSyncScenario } from "../__support__/filesync.js";
 import { describeWithAuth } from "../utils.js";
 
 describe("push", () => {
-  let ctx: Context<PushArgs>;
-
   describeWithAuth(() => {
-    beforeEach(() => {
-      ctx = makeContext({ parse: args, argv: ["push"] });
-    });
-
     it("sends changes from the local filesystem to gadget", async () => {
       const { localDir, expectDirs } = await makeSyncScenario({
         localFiles: {
@@ -44,7 +38,7 @@ describe("push", () => {
         await fs.outputFile(localDir.absolute(filename), filename);
       }
 
-      await push(ctx);
+      await push.run(testCtx, makeArgs(push.args));
 
       await expectDirs().resolves.toMatchInlineSnapshot(`
         {
@@ -136,7 +130,7 @@ describe("push", () => {
         await fs.outputFile(localDir.absolute(`tmp/${filename}`), filename);
       }
 
-      await push(ctx);
+      await push.run(testCtx, makeArgs(push.args));
 
       await expectDirs().resolves.toMatchInlineSnapshot(`
         {

--- a/spec/commands/status.spec.ts
+++ b/spec/commands/status.spec.ts
@@ -1,7 +1,7 @@
-import { beforeEach, describe, it } from "vitest";
-import { args, run as status, type StatusArgs } from "../../src/commands/status.js";
-import type { Context } from "../../src/services/command/context.js";
-import { makeContext } from "../__support__/context.js";
+import { describe, it } from "vitest";
+import * as status from "../../src/commands/status.js";
+import { makeArgs } from "../__support__/arg.js";
+import { testCtx } from "../__support__/context.js";
 import { makeSyncScenario } from "../__support__/filesync.js";
 import { expectStdout } from "../__support__/output.js";
 import { mockSystemTime } from "../__support__/time.js";
@@ -10,16 +10,7 @@ import { describeWithAuth } from "../utils.js";
 describe("status", () => {
   mockSystemTime();
 
-  let ctx: Context<StatusArgs>;
-
   describeWithAuth(() => {
-    beforeEach(() => {
-      ctx = makeContext({
-        parse: args,
-        argv: ["status"],
-      });
-    });
-
     it("prints the expected message when nothing has changed", async () => {
       await makeSyncScenario({
         localFiles: {
@@ -27,7 +18,7 @@ describe("status", () => {
         },
       });
 
-      await status(ctx);
+      await status.run(testCtx, makeArgs(status.args));
 
       expectStdout().toMatchInlineSnapshot(`
       "Application  test
@@ -53,7 +44,7 @@ describe("status", () => {
         },
       });
 
-      await status(ctx);
+      await status.run(testCtx, makeArgs(status.args));
 
       expectStdout().toMatchInlineSnapshot(`
       "Application  test
@@ -86,7 +77,7 @@ describe("status", () => {
         },
       });
 
-      await status(ctx);
+      await status.run(testCtx, makeArgs(status.args));
 
       expectStdout().toMatchInlineSnapshot(`
       "Application  test
@@ -120,7 +111,7 @@ describe("status", () => {
         },
       });
 
-      await status(ctx);
+      await status.run(testCtx, makeArgs(status.args));
 
       expectStdout().toMatchInlineSnapshot(`
         "Application  test

--- a/spec/commands/version.spec.ts
+++ b/spec/commands/version.spec.ts
@@ -1,11 +1,11 @@
 import { describe, it } from "vitest";
-import { run } from "../../src/commands/version.js";
-import { makeContext } from "../__support__/context.js";
+import * as version from "../../src/commands/version.js";
+import { testCtx } from "../__support__/context.js";
 import { expectStdout } from "../__support__/output.js";
 
 describe("version", () => {
   it("prints the version", async () => {
-    await run(makeContext());
+    await version.run(testCtx, { _: [] });
 
     expectStdout().toEqual("1.2.3\n");
   });

--- a/spec/commands/whoami.spec.ts
+++ b/spec/commands/whoami.spec.ts
@@ -1,22 +1,15 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { run } from "../../src/commands/whoami.js";
-import { type Context } from "../../src/services/command/context.js";
+import { describe, expect, it } from "vitest";
+import * as whoami from "../../src/commands/whoami.js";
 import * as user from "../../src/services/user/user.js";
-import { makeContext } from "../__support__/context.js";
+import { testCtx } from "../__support__/context.js";
 import { mock } from "../__support__/mock.js";
 import { expectStdout } from "../__support__/output.js";
 
 describe("whoami", () => {
-  let ctx: Context;
-
-  beforeEach(() => {
-    ctx = makeContext();
-  });
-
   it("outputs the current user", async () => {
     mock(user, "getUser", () => ({ id: 1, email: "test@example.com", name: "Jane Doe" }));
 
-    await run(ctx);
+    await whoami.run(testCtx, { _: [] });
 
     expect(user.getUser).toHaveBeenCalled();
     expectStdout().toMatchInlineSnapshot(`
@@ -28,7 +21,7 @@ describe("whoami", () => {
   it("outputs only the email if the current user's name is missing", async () => {
     mock(user, "getUser", () => ({ id: 1, email: "test@example.com" }));
 
-    await run(ctx);
+    await whoami.run(testCtx, { _: [] });
 
     expect(user.getUser).toHaveBeenCalled();
     expectStdout().toMatchInlineSnapshot(`
@@ -40,7 +33,7 @@ describe("whoami", () => {
   it("outputs 'not logged in' if the current user is undefined", async () => {
     mock(user, "getUser", () => undefined);
 
-    await run(ctx);
+    await whoami.run(testCtx, { _: [] });
 
     expect(user.getUser).toHaveBeenCalled();
     expectStdout().toMatchInlineSnapshot(`

--- a/spec/ggt.spec.ts
+++ b/spec/ggt.spec.ts
@@ -9,7 +9,7 @@ import { isAbortError } from "../src/services/util/is.js";
 import * as json from "../src/services/util/json.js";
 import { PromiseSignal } from "../src/services/util/promise.js";
 import type { AnyFunction } from "../src/services/util/types.js";
-import { makeRootContext } from "./__support__/context.js";
+import { testCtx } from "./__support__/context.js";
 import { mock } from "./__support__/mock.js";
 
 describe("ggt", () => {
@@ -39,8 +39,7 @@ describe("ggt", () => {
       return process;
     });
 
-    process.argv = ["node", "ggt", "test"];
-    await ggt(makeRootContext());
+    await ggt(testCtx);
 
     expect(signalled).toBe(true);
     onSignal!();

--- a/spec/services/app/app.spec.ts
+++ b/spec/services/app/app.spec.ts
@@ -1,32 +1,25 @@
 import nock from "nock";
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getApps } from "../../../src/services/app/app.js";
-import type { Context } from "../../../src/services/command/context.js";
 import { config } from "../../../src/services/config/config.js";
 import { loadCookie } from "../../../src/services/http/auth.js";
 import { testApp } from "../../__support__/app.js";
-import { makeContext } from "../../__support__/context.js";
+import { testCtx } from "../../__support__/context.js";
 import { loginTestUser } from "../../__support__/user.js";
 
 describe("getApps", () => {
-  let ctx: Context;
-
-  beforeEach(() => {
-    ctx = makeContext();
-  });
-
   it("returns the available apps if the session is set", async () => {
     loginTestUser();
 
     const apps = [testApp];
-    nock(`https://${config.domains.services}`).get("/auth/api/apps").matchHeader("cookie", loadCookie(ctx)!).reply(200, apps);
+    nock(`https://${config.domains.services}`).get("/auth/api/apps").matchHeader("cookie", loadCookie(testCtx)!).reply(200, apps);
 
-    await expect(getApps(ctx)).resolves.toEqual(apps);
+    await expect(getApps(testCtx)).resolves.toEqual(apps);
     expect(nock.isDone()).toBe(true);
   });
 
   it("returns an empty array if the session is not set", async () => {
-    expect(loadCookie(ctx)).toBeUndefined();
-    await expect(getApps(ctx)).resolves.toEqual([]);
+    expect(loadCookie(testCtx)).toBeUndefined();
+    await expect(getApps(testCtx)).resolves.toEqual([]);
   });
 });

--- a/spec/services/command/command.spec.ts
+++ b/spec/services/command/command.spec.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { Commands, importCommand, type CommandModule } from "../../../src/services/command/command.js";
-import { makeRootContext } from "../../__support__/context.js";
+import { testCtx } from "../../__support__/context.js";
 
 describe.each(Commands)("%s", (command) => {
   let cmd: CommandModule;
@@ -12,7 +12,7 @@ describe.each(Commands)("%s", (command) => {
   it("has a usage function", () => {
     expect(cmd.usage).toBeDefined();
     expect(cmd.usage).toBeInstanceOf(Function);
-    expect(cmd.usage(makeRootContext())).toBeTypeOf("string");
+    expect(cmd.usage(testCtx)).toBeTypeOf("string");
   });
 
   it("has a run function", () => {

--- a/spec/services/command/context.spec.ts
+++ b/spec/services/command/context.spec.ts
@@ -2,37 +2,11 @@ import { describe, expect, it, test, vi } from "vitest";
 import { Context, type OnAbort } from "../../../src/services/command/context.js";
 import { mockOnce } from "../../__support__/mock.js";
 
-describe("Context.init", () => {
-  it("parses args", () => {
-    const ctx = Context.init({ name: "test", parse: { "--foo": Boolean }, argv: ["--foo"] });
-    expect(ctx.args["--foo"]).toBe(true);
-  });
-});
-
-describe("Context.child", () => {
-  it("returns a new context with additional args", () => {
-    const ctx = Context.init({ name: "test", parse: { "--foo": Boolean }, argv: ["--foo", "--bar"], permissive: true });
-    expect(ctx.args._).toEqual(["--bar"]);
-
-    const child = ctx.child({ parse: { "--bar": Boolean } });
-    expect(child.args["--foo"]).toBe(true);
-    expect(child.args["--bar"]).toBe(true);
-  });
-
-  it("returns a new context with overwritten args", () => {
-    const ctx = Context.init({ name: "test", parse: { "--foo": Boolean }, argv: ["--foo"] });
-    expect(ctx.args["--foo"]).toBe(true);
-
-    const child = ctx.child({ overwrite: { "--foo": false } });
-    expect(child.args["--foo"]).toBe(false);
-  });
-});
-
 describe("Context.onAbort", () => {
   it("calls the callback when the context is aborted", () => {
     const callback = vi.fn();
 
-    const ctx = Context.init({ name: "test", parse: {}, argv: [] });
+    const ctx = Context.init({ name: "test" });
     ctx.onAbort(callback);
     ctx.abort("reason");
 
@@ -51,7 +25,7 @@ describe("Context.onAbort", () => {
       throw new Error("test");
     });
 
-    const ctx = Context.init({ name: "test", parse: {}, argv: [] });
+    const ctx = Context.init({ name: "test" });
     ctx.onAbort(callback);
 
     await expect(onAbort!(undefined)).resolves.not.toThrow();
@@ -61,7 +35,7 @@ describe("Context.onAbort", () => {
   it("only calls the callback once", () => {
     const callback = vi.fn();
 
-    const ctx = Context.init({ name: "test", parse: {}, argv: [] });
+    const ctx = Context.init({ name: "test" });
     ctx.onAbort(callback);
     ctx.abort();
     ctx.abort();
@@ -72,11 +46,11 @@ describe("Context.onAbort", () => {
 
 test("re-assigning the context parameter doesn't change the original context", () => {
   const command = (ctxParam: Context): Context => {
-    ctxParam = ctxParam.child({ parse: { "--foo": Boolean } });
+    ctxParam = ctxParam.child({ name: "other" });
     return ctxParam;
   };
 
-  const ctx = Context.init({ name: "test", parse: {}, argv: [] });
+  const ctx = Context.init({ name: "test" });
   const otherCtx = command(ctx);
 
   expect(ctx).not.toBe(otherCtx);

--- a/spec/services/filesync/changes.spec.ts
+++ b/spec/services/filesync/changes.spec.ts
@@ -1,24 +1,17 @@
 import figures from "figures";
-import { beforeEach, describe, it } from "vitest";
-import type { Context } from "../../../src/services/command/context.js";
+import { describe, it } from "vitest";
 import { Changes, printChanges } from "../../../src/services/filesync/changes.js";
-import { makeContext } from "../../__support__/context.js";
+import { testCtx } from "../../__support__/context.js";
 import { expectStdout } from "../../__support__/output.js";
 
 describe("printChanges", () => {
-  let ctx: Context;
-
-  beforeEach(() => {
-    ctx = makeContext();
-  });
-
   it("prints the changes in present tense", () => {
     const changes = new Changes();
     changes.set("foo", { type: "create" });
     changes.set("bar", { type: "update" });
     changes.set("baz", { type: "delete" });
 
-    printChanges(ctx, { changes, tense: "present", title: "→ Sent to example (staging) 12:00:00 PM" });
+    printChanges(testCtx, { changes, tense: "present", title: "→ Sent to example (staging) 12:00:00 PM" });
     expectStdout().toMatchInlineSnapshot(`
       "→ Sent to example (staging) 12:00:00 PM
       ±  bar  update
@@ -34,7 +27,7 @@ describe("printChanges", () => {
     changes.set("bar", { type: "update" });
     changes.set("baz", { type: "delete" });
 
-    printChanges(ctx, { changes, tense: "past", title: `Pulled files. ${figures.arrowLeft} 12:00:00 PM` });
+    printChanges(testCtx, { changes, tense: "past", title: `Pulled files. ${figures.arrowLeft} 12:00:00 PM` });
     expectStdout().toMatchInlineSnapshot(`
       "Pulled files. ← 12:00:00 PM
       ±  bar  updated
@@ -62,7 +55,7 @@ describe("printChanges", () => {
       ["file-12", { type: "delete" }],
     ]);
 
-    printChanges(ctx, { changes, tense: "present", title: "→ Sent to example (staging) 12:00:00 PM" });
+    printChanges(testCtx, { changes, tense: "present", title: "→ Sent to example (staging) 12:00:00 PM" });
     expectStdout().toMatchInlineSnapshot(`
       "→ Sent to example (staging) 12:00:00 PM
       +  file-01  create

--- a/spec/services/filesync/conflicts.spec.ts
+++ b/spec/services/filesync/conflicts.spec.ts
@@ -1,17 +1,10 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import type { Context } from "../../../src/services/command/context.js";
+import { describe, expect, it } from "vitest";
 import { getConflicts } from "../../../src/services/filesync/conflicts.js";
 import { getNecessaryChanges } from "../../../src/services/filesync/hashes.js";
-import { makeContext } from "../../__support__/context.js";
+import { testCtx } from "../../__support__/context.js";
 import { makeHashes } from "../../__support__/filesync.js";
 
 describe("getConflicts", () => {
-  let ctx: Context;
-
-  beforeEach(() => {
-    ctx = makeContext();
-  });
-
   it("returns conflicting changes", async () => {
     const { localFilesVersionHashes, environmentHashes, localHashes } = await makeHashes({
       filesVersionFiles: {
@@ -31,8 +24,8 @@ describe("getConflicts", () => {
       },
     });
 
-    const localChanges = getNecessaryChanges(ctx, { from: localFilesVersionHashes, to: localHashes });
-    const environmentChanges = getNecessaryChanges(ctx, { from: localFilesVersionHashes, to: environmentHashes });
+    const localChanges = getNecessaryChanges(testCtx, { from: localFilesVersionHashes, to: localHashes });
+    const environmentChanges = getNecessaryChanges(testCtx, { from: localFilesVersionHashes, to: environmentHashes });
     const conflicts = getConflicts({ localChanges, environmentChanges });
 
     expect(Object.fromEntries(conflicts)).toEqual({
@@ -76,8 +69,8 @@ describe("getConflicts", () => {
       },
     });
 
-    const localChanges = getNecessaryChanges(ctx, { from: localFilesVersionHashes, to: localHashes });
-    const environmentChanges = getNecessaryChanges(ctx, { from: localFilesVersionHashes, to: environmentHashes });
+    const localChanges = getNecessaryChanges(testCtx, { from: localFilesVersionHashes, to: localHashes });
+    const environmentChanges = getNecessaryChanges(testCtx, { from: localFilesVersionHashes, to: environmentHashes });
     const conflicts = getConflicts({ localChanges, environmentChanges });
 
     expect(Object.fromEntries(conflicts)).toEqual({});

--- a/spec/services/output/report.spec.ts
+++ b/spec/services/output/report.spec.ts
@@ -1,14 +1,13 @@
-import * as Sentry from "@sentry/node";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { GGTError, IsBug, UnexpectedError, reportErrorAndExit } from "../../../src/services/output/report.js";
-import { makeContext } from "../../__support__/context.js";
+import { testCtx } from "../../__support__/context.js";
 import { expectStdout } from "../../__support__/output.js";
 import { expectProcessExit } from "../../__support__/process.js";
 
 describe("reportErrorAndExit", () => {
-  // Cannot redefine property: captureException
-  it("renders and reports errors then exits", { skip: true }, async () => {
-    vi.spyOn(Sentry, "captureException");
+  it("renders and reports errors then exits", async () => {
+    // Cannot redefine property: captureException
+    // vi.spyOn(Sentry, "captureException");
 
     class TestError extends GGTError {
       override isBug = IsBug.MAYBE;
@@ -24,7 +23,7 @@ describe("reportErrorAndExit", () => {
 
     const error = new TestError();
 
-    await expectProcessExit(() => reportErrorAndExit(makeContext(), error), 1);
+    await expectProcessExit(() => reportErrorAndExit(testCtx, error), 1);
 
     expectStdout().toMatchInlineSnapshot(`
       "Boom!
@@ -35,7 +34,7 @@ describe("reportErrorAndExit", () => {
       "
     `);
 
-    expect(Sentry.captureException).toHaveBeenCalledWith(error, expect.objectContaining({ event_id: error.id }));
+    // expect(Sentry.captureException).toHaveBeenCalledWith(error, expect.objectContaining({ event_id: error.id }));
   });
 });
 
@@ -50,7 +49,7 @@ describe("UnexpectedError", () => {
       "An unexpected error occurred.
 
       Error: Whoops!
-          at spec/services/output/report.spec.ts:44:19
+          at spec/services/output/report.spec.ts:43:19
           at ...
           at ...
           at ...

--- a/spec/services/output/update.spec.ts
+++ b/spec/services/output/update.spec.ts
@@ -2,21 +2,14 @@ import fs from "fs-extra";
 import ms from "ms";
 import nock from "nock";
 import path from "node:path";
-import { beforeEach, describe, expect, it } from "vitest";
-import type { Context } from "../../../src/services/command/context.js";
+import { describe, expect, it } from "vitest";
 import { config } from "../../../src/services/config/config.js";
 import { getDistTags, shouldCheckForUpdate, warnIfUpdateAvailable } from "../../../src/services/output/update.js";
 import { packageJson } from "../../../src/services/util/package-json.js";
-import { makeContext, testCtx } from "../../__support__/context.js";
+import { testCtx } from "../../__support__/context.js";
 import { expectStdout } from "../../__support__/output.js";
 
 describe("getDistTags", () => {
-  let ctx: Context;
-
-  beforeEach(() => {
-    ctx = makeContext();
-  });
-
   it("returns the dist tags", async () => {
     const distTags = {
       latest: "1.0.0",
@@ -28,7 +21,7 @@ describe("getDistTags", () => {
       "dist-tags": distTags,
     });
 
-    await expect(getDistTags(ctx)).resolves.toEqual(distTags);
+    await expect(getDistTags(testCtx)).resolves.toEqual(distTags);
   });
 
   it("throws if the response is invalid", async () => {
@@ -42,7 +35,7 @@ describe("getDistTags", () => {
         },
       });
 
-    await expect(getDistTags(ctx)).rejects.toThrow();
+    await expect(getDistTags(testCtx)).rejects.toThrow();
   });
 });
 
@@ -65,12 +58,6 @@ describe("shouldCheckForUpdate", () => {
 });
 
 describe("warnIfUpdateAvailable", () => {
-  let ctx: Context;
-
-  beforeEach(() => {
-    ctx = makeContext();
-  });
-
   it("logs a warning if an update is available (latest)", async () => {
     packageJson.version = "1.0.0";
 
@@ -86,7 +73,7 @@ describe("warnIfUpdateAvailable", () => {
 
     await expect(shouldCheckForUpdate(testCtx)).resolves.toBeTruthy();
 
-    await warnIfUpdateAvailable(ctx);
+    await warnIfUpdateAvailable(testCtx);
 
     await expect(shouldCheckForUpdate(testCtx)).resolves.toBeFalsy();
 
@@ -117,7 +104,7 @@ describe("warnIfUpdateAvailable", () => {
 
     await expect(shouldCheckForUpdate(testCtx)).resolves.toBeTruthy();
 
-    await warnIfUpdateAvailable(ctx);
+    await warnIfUpdateAvailable(testCtx);
 
     await expect(shouldCheckForUpdate(testCtx)).resolves.toBeFalsy();
 
@@ -161,7 +148,7 @@ describe("warnIfUpdateAvailable", () => {
 
     await expect(shouldCheckForUpdate(testCtx)).resolves.toBeTruthy();
 
-    await warnIfUpdateAvailable(ctx);
+    await warnIfUpdateAvailable(testCtx);
 
     await expect(shouldCheckForUpdate(testCtx)).resolves.toBeFalsy();
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -57,9 +57,9 @@ export const usage: Usage = (_ctx) => {
 `;
 };
 
-export const run: Run<DeployArgs> = async (ctx) => {
+export const run: Run<DeployArgs> = async (ctx, args) => {
   const directory = await loadSyncJsonDirectory(process.cwd());
-  const syncJson = await SyncJson.loadOrInit(ctx, { directory });
+  const syncJson = await SyncJson.loadOrInit(ctx, { args, directory });
 
   println({
     ensureEmptyLineAbove: true,
@@ -111,14 +111,14 @@ export const run: Run<DeployArgs> = async (ctx) => {
       });
     }
 
-    await filesync.push(ctx, { hashes, force: implicitForce || ctx.args["--force"] });
+    await filesync.push(ctx, { hashes, force: implicitForce || args["--force"] });
   }
 
   const variables = {
     localFilesVersion: String(syncJson.filesVersion),
-    force: ctx.args["--allow-problems"],
-    allowDeletedData: ctx.args["--allow-data-delete"],
-    allowCharges: ctx.args["--allow-charges"],
+    force: args["--allow-problems"],
+    allowDeletedData: args["--allow-data-delete"],
+    allowCharges: args["--allow-charges"],
   };
 
   let spinner: spinner | undefined;
@@ -224,8 +224,8 @@ export const run: Run<DeployArgs> = async (ctx) => {
           await confirm("Do you want to continue?");
           subscription.resubscribe({ ...variables, force: true, allowDeletedData: true });
         } else {
-          const allowDataDelete = ctx.args["--allow-data-delete"];
-          const allowProblems = ctx.args["--allow-problems"];
+          const allowDataDelete = args["--allow-data-delete"];
+          const allowProblems = args["--allow-problems"];
 
           if (!allowDataDelete && !allowProblems) {
             throw new UnexpectedError("expected --allow-data-delete or --allow-problems to be true");

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -65,14 +65,14 @@ export const usage: Usage = (_ctx) => {
   `;
 };
 
-export const run: Run<OpenArgs> = async (ctx) => {
+export const run: Run<OpenArgs> = async (ctx, args) => {
   const directory = await loadSyncJsonDirectory(process.cwd());
-  const syncJson = await SyncJson.load(ctx, { directory });
+  const syncJson = await SyncJson.load(ctx, { args, directory });
   if (!syncJson) {
-    throw new UnknownDirectoryError(ctx, { directory });
+    throw new UnknownDirectoryError(ctx, { args, directory });
   }
 
-  const location = ctx.args._[0] as Location | undefined;
+  const location = args._[0] as Location | undefined;
   if (!location) {
     await open(`https://${syncJson.app.primaryDomain}/edit/${syncJson.env.name}`);
     println`
@@ -109,12 +109,12 @@ export const run: Run<OpenArgs> = async (ctx) => {
     }
     case "data":
     case "schema": {
-      const view = ctx.args._[0];
+      const view = args._[0];
       const remoteModelApiIdentifiers = (await getModels(ctx)).map((e) => e.apiIdentifier);
 
-      let modelApiIdentifier = ctx.args._[1];
+      let modelApiIdentifier = args._[1];
       if (!modelApiIdentifier) {
-        if (ctx.args["--show-all"]) {
+        if (args["--show-all"]) {
           modelApiIdentifier = await select({ choices: remoteModelApiIdentifiers, content: "Which model do you wish to open?" });
         } else {
           throw new ArgError(sprint`

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -35,8 +35,8 @@ export const usage: Usage = (_ctx) => {
   `;
 };
 
-export const run: Run<PullArgs> = async (ctx) => {
-  if (ctx.args._.length > 0) {
+export const run: Run<PullArgs> = async (ctx, args) => {
+  if (args._.length > 0) {
     throw new ArgError(sprint`
       "ggt pull" does not take any positional arguments.
 
@@ -48,7 +48,7 @@ export const run: Run<PullArgs> = async (ctx) => {
   }
 
   const directory = await loadSyncJsonDirectory(process.cwd());
-  const syncJson = await SyncJson.loadOrInit(ctx, { directory });
+  const syncJson = await SyncJson.loadOrInit(ctx, { args, directory });
   const filesync = new FileSync(syncJson);
   const hashes = await filesync.hashes(ctx);
 

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -35,8 +35,8 @@ export const usage: Usage = (_ctx) => {
   `;
 };
 
-export const run: Run<typeof args> = async (ctx) => {
-  if (ctx.args._.length > 0) {
+export const run: Run<typeof args> = async (ctx, args) => {
+  if (args._.length > 0) {
     throw new ArgError(sprint`
       "ggt push" does not take any positional arguments.
 
@@ -46,7 +46,7 @@ export const run: Run<typeof args> = async (ctx) => {
   }
 
   const directory = await loadSyncJsonDirectory(process.cwd());
-  const syncJson = await SyncJson.loadOrInit(ctx, { directory });
+  const syncJson = await SyncJson.loadOrInit(ctx, { args, directory });
   const filesync = new FileSync(syncJson);
   const hashes = await filesync.hashes(ctx);
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,4 +1,4 @@
-import { ArgError } from "../services/command/arg.js";
+import { ArgError, type ArgsDefinitionResult } from "../services/command/arg.js";
 import type { Run, Usage } from "../services/command/command.js";
 import { getConflicts, printConflicts } from "../services/filesync/conflicts.js";
 import { UnknownDirectoryError } from "../services/filesync/error.js";
@@ -7,6 +7,7 @@ import { SyncJson, SyncJsonArgs, loadSyncJsonDirectory } from "../services/files
 import { sprint } from "../services/output/sprint.js";
 
 export type StatusArgs = typeof args;
+export type StatusArgsResult = ArgsDefinitionResult<StatusArgs>;
 
 export const args = SyncJsonArgs;
 
@@ -19,8 +20,8 @@ export const usage: Usage = () => {
   `;
 };
 
-export const run: Run<StatusArgs> = async (ctx) => {
-  if (ctx.args._.length > 0) {
+export const run: Run<StatusArgs> = async (ctx, args) => {
+  if (args._.length > 0) {
     throw new ArgError(sprint`
       "ggt status" does not take any positional arguments.
 
@@ -32,9 +33,9 @@ export const run: Run<StatusArgs> = async (ctx) => {
   }
 
   const directory = await loadSyncJsonDirectory(process.cwd());
-  const syncJson = await SyncJson.load(ctx, { directory });
+  const syncJson = await SyncJson.load(ctx, { args, directory });
   if (!syncJson) {
-    throw new UnknownDirectoryError(ctx, { directory });
+    throw new UnknownDirectoryError(ctx, { args, directory });
   }
 
   syncJson.print();

--- a/src/ggt.ts
+++ b/src/ggt.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import ms from "ms";
 import * as root from "./commands/root.js";
+import { parseArgs } from "./services/command/arg.js";
 import { Context } from "./services/command/context.js";
 import { output } from "./services/output/output.js";
 import { println } from "./services/output/print.js";
@@ -9,58 +10,63 @@ import { activeSpinner, spin } from "./services/output/spinner.js";
 import { installJsonExtensions } from "./services/util/json.js";
 
 export const ggt = async (ctx = Context.init({ name: "ggt" })): Promise<void> => {
-  installJsonExtensions();
-  await installErrorHandlers(ctx);
-
   try {
-    let stopping = false;
+    const rootArgs = parseArgs(root.args, { argv: process.argv.slice(2), permissive: true });
 
-    for (const signal of ["SIGINT", "SIGTERM"] as const) {
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      process.on(signal, async () => {
-        if (stopping) {
-          return;
-        }
+    installJsonExtensions();
+    await installErrorHandlers(ctx, rootArgs);
+    installSignalHandler(ctx);
 
-        stopping = true;
-        ctx.log.trace("received signal", { signal });
-
-        setTimeout(() => {
-          // when ggt is run with npx, and the user presses ctrl+c, ggt
-          // receives SIGINT twice in quick succession. in order to
-          // prevent the second SIGINT from triggering the force exit
-          // listener, we wait a bit in this setTimeout before adding it
-          process.once(signal, () => {
-            println(" Exiting immediately");
-            process.exit(1);
-          });
-        }, ms("100ms")).unref();
-
-        // ctrl+c was pressed, so we need to clear the line
-        output.writeStdout("\n");
-
-        // if there was any sticky text, it needs to be persisted now
-        activeSpinner?.clear();
-        output.persistFooter();
-
-        const spinner = spin({
-          successSymbol: "👋",
-          content: `Stopping ${chalk.gray("Press Ctrl+C again to force")}`,
-        });
-
-        try {
-          ctx.abort();
-          await ctx.done;
-          spinner.succeed("Goodbye!");
-        } catch (error) {
-          spinner.fail();
-          await reportErrorAndExit(ctx, error);
-        }
-      });
-    }
-
-    await root.run(ctx);
+    await root.run(ctx, rootArgs);
   } catch (error) {
     await reportErrorAndExit(ctx, error);
+  }
+};
+
+const installSignalHandler = (ctx: Context): void => {
+  let stopping = false;
+
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    process.on(signal, async () => {
+      if (stopping) {
+        return;
+      }
+
+      stopping = true;
+      ctx.log.trace("received signal", { signal });
+
+      setTimeout(() => {
+        // when ggt is run with npx, and the user presses ctrl+c, ggt
+        // receives SIGINT twice in quick succession. in order to
+        // prevent the second SIGINT from triggering the force exit
+        // listener, we wait a bit in this setTimeout before adding it
+        process.once(signal, () => {
+          println(" Exiting immediately");
+          process.exit(1);
+        });
+      }, ms("100ms")).unref();
+
+      // ctrl+c was pressed, so we need to clear the line
+      output.writeStdout("\n");
+
+      // if there was any sticky text, it needs to be persisted now
+      activeSpinner?.clear();
+      output.persistFooter();
+
+      const spinner = spin({
+        successSymbol: "👋",
+        content: `Stopping ${chalk.gray("Press Ctrl+C again to force")}`,
+      });
+
+      try {
+        ctx.abort();
+        await ctx.done;
+        spinner.succeed("Goodbye!");
+      } catch (error) {
+        spinner.fail();
+        await reportErrorAndExit(ctx, error);
+      }
+    });
   }
 };

--- a/src/services/app/api/api.ts
+++ b/src/services/app/api/api.ts
@@ -47,6 +47,7 @@ export class Api {
     assert(name, "query name not found");
 
     const ctx = this.ctx.child({
+      name: "api",
       fields: { edit: { query: name } },
       devFields: { edit: { query: name, variables: unthunk(variables) } },
     });
@@ -85,6 +86,7 @@ export class Api {
    * @param request.http - {@linkcode HttpOptions} to pass to http.
    * @returns The data returned by the server.
    */
+  // TODO: remove this -- it isn't used, and we shouldn't be mutating a Gadget app's data anyway
   async mutate<Mutation extends GraphQLMutation>({
     mutation,
     variables,
@@ -98,6 +100,7 @@ export class Api {
     assert(name, "mutation name not found");
 
     const ctx = this.ctx.child({
+      name: "api",
       fields: { edit: { mutation: name } },
       devFields: { edit: { mutation: name, variables: unthunk(variables) } },
     });
@@ -127,6 +130,7 @@ export class Api {
    * @param options.onComplete - A callback that will be called when the subscription ends.
    * @returns A function to unsubscribe from the subscription.
    */
+  // TODO: remove this -- it isn't used
   subscribe<Subscription extends GraphQLSubscription>({
     onData,
     ...options
@@ -141,6 +145,7 @@ export class Api {
     assert(name, "subscription name not found");
 
     let ctx = this.ctx.child({
+      name: "api",
       fields: { edit: { subscription: name } },
       devFields: { edit: { subscription: name, variables: unthunk(options.variables) } },
     });
@@ -174,6 +179,7 @@ export class Api {
         }
 
         ctx = this.ctx.child({
+          name: "api",
           fields: { edit: { subscription: name } },
           devFields: { edit: { subscription: name, variables: unthunk(options.variables) } },
         });

--- a/src/services/app/edit/edit.ts
+++ b/src/services/app/edit/edit.ts
@@ -47,6 +47,7 @@ export class Edit {
     assert(name, "query name not found");
 
     const ctx = this.ctx.child({
+      name: "edit",
       fields: { edit: { query: name } },
       devFields: { edit: { query: name, variables: unthunk(variables) } },
     });
@@ -98,6 +99,7 @@ export class Edit {
     assert(name, "mutation name not found");
 
     const ctx = this.ctx.child({
+      name: "edit",
       fields: { edit: { mutation: name } },
       devFields: { edit: { mutation: name, variables: unthunk(variables) } },
     });
@@ -141,6 +143,7 @@ export class Edit {
     assert(name, "subscription name not found");
 
     let ctx = this.ctx.child({
+      name: "edit",
       fields: { edit: { subscription: name } },
       devFields: { edit: { subscription: name, variables: unthunk(options.variables) } },
     });
@@ -176,6 +179,7 @@ export class Edit {
         }
 
         ctx = this.ctx.child({
+          name: "edit",
           fields: { edit: { subscription: name } },
           devFields: { edit: { subscription: name, variables: unthunk(options.variables) } },
         });

--- a/src/services/command/command.ts
+++ b/src/services/command/command.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert";
 import type { EmptyObject, Promisable } from "type-fest";
-import type { RootArgs } from "../../commands/root.js";
-import type { ArgsDefinition } from "./arg.js";
+import type { ArgsDefinition, ArgsDefinitionResult } from "./arg.js";
 import type { Context } from "./context.js";
 
 /**
@@ -30,7 +29,7 @@ export const isCommand = (command: string): command is Command => {
 /**
  * A command module is a file in the src/commands/ directory.
  */
-export type CommandModule<Args extends ArgsDefinition = EmptyObject, ParentArgs extends ArgsDefinition = RootArgs> = {
+export type CommandModule<Args extends ArgsDefinition = EmptyObject> = {
   /**
    * The command's {@link ArgsDefinition args}.
    */
@@ -42,26 +41,21 @@ export type CommandModule<Args extends ArgsDefinition = EmptyObject, ParentArgs 
   usage: Usage;
 
   /**
-   * The command's {@link Run command}.
+   * The command's {@link Run run} function.
    */
-  run: Run<Args, ParentArgs>;
+  run: Run<Args>;
 };
 
 /**
  * A {@linkcode Command command}'s usage is a function that returns a
- * string describing how to use the command. The function receives its
- * parent command's context.
+ * string describing how to use the command.
  */
 export type Usage = (ctx: Context) => string;
 
 /**
  * The function that is run when the command is called.
- *
- * @param ctx - A {@linkcode Context} with the command's {@linkcode Args} and {@linkcode ParentArgs}.
  */
-export type Run<Args extends ArgsDefinition = EmptyObject, ParentArgs extends ArgsDefinition = RootArgs> = (
-  ctx: Context<Args, ParentArgs>,
-) => Promisable<void>;
+export type Run<Args extends ArgsDefinition = EmptyObject> = (ctx: Context, args: ArgsDefinitionResult<Args>) => Promisable<void>;
 
 /**
  * Imports a command module.

--- a/src/services/filesync/error.ts
+++ b/src/services/filesync/error.ts
@@ -7,7 +7,7 @@ import { GGTError, IsBug } from "../output/report.js";
 import { sprint, sprintln } from "../output/sprint.js";
 import { isGraphQLErrors, isGraphQLResult, isObject, isString } from "../util/is.js";
 import type { Directory } from "./directory.js";
-import type { SyncJsonArgs } from "./sync-json.js";
+import type { SyncJsonArgsResult } from "./sync-json.js";
 
 export class YarnNotFoundError extends GGTError {
   isBug = IsBug.NO;
@@ -31,8 +31,8 @@ export class UnknownDirectoryError extends GGTError {
   isBug = IsBug.NO;
 
   constructor(
-    readonly ctx: Context<SyncJsonArgs>,
-    readonly opts: { directory: Directory },
+    readonly ctx: Context,
+    readonly opts: { directory: Directory; args: SyncJsonArgsResult },
   ) {
     super('The ".gadget/sync.json" file was invalid or not found');
   }
@@ -62,7 +62,7 @@ export class UnknownDirectoryError extends GGTError {
           If you're running "ggt dev" for the first time, we recommend
           using a gadget specific directory like this:
 
-            ggt dev ~/gadget/${this.ctx.args["--app"] ?? "<name>"}
+            ggt dev ~/gadget/${this.opts.args["--app"] ?? "<name>"}
 
           To use a non-empty directory without a ".gadget/sync.json" file,
           run "ggt dev" again with the "--allow-unknown-directory" flag:

--- a/src/services/http/http.ts
+++ b/src/services/http/http.ts
@@ -25,7 +25,7 @@ const getContext = (options: HttpOptions): Context => {
     `),
   );
 
-  return options.context["ctx"] as Context;
+  return options.context["ctx"];
 };
 
 /**

--- a/src/services/output/report.ts
+++ b/src/services/output/report.ts
@@ -1,6 +1,7 @@
 import cleanStack from "clean-stack";
 import { randomUUID } from "node:crypto";
 import terminalLink from "terminal-link";
+import type { RootArgsResult } from "../../commands/root.js";
 import type { Context } from "../command/context.js";
 import { env } from "../config/env.js";
 import { isAbortError } from "../util/is.js";
@@ -32,9 +33,9 @@ export const reportErrorAndExit = async (ctx: Context, cause: unknown): Promise<
   }
 };
 
-export const installErrorHandlers = async (ctx: Context): Promise<void> => {
+export const installErrorHandlers = async (ctx: Context, args: RootArgsResult): Promise<void> => {
   ctx.log.debug("installing error handlers");
-  await initSentry(ctx);
+  await initSentry(ctx, args);
 
   const handleError = (error: unknown) => void reportErrorAndExit(ctx, error);
   process.once("uncaughtException", handleError);

--- a/src/services/output/sentry.ts
+++ b/src/services/output/sentry.ts
@@ -1,6 +1,7 @@
 import type * as SentryModule from "@sentry/node";
 import ms from "ms";
 import os from "node:os";
+import type { RootArgsResult } from "../../commands/root.js";
 import type { Context } from "../command/context.js";
 import { config } from "../config/config.js";
 import { env } from "../config/env.js";
@@ -10,8 +11,8 @@ import type { GGTError } from "./report.js";
 
 let Sentry: typeof SentryModule | undefined;
 
-export const initSentry = async (ctx: Context): Promise<void> => {
-  if (!ctx.args["--telemetry"]) {
+export const initSentry = async (_ctx: Context, args: RootArgsResult): Promise<void> => {
+  if (!args["--telemetry"]) {
     return;
   }
 
@@ -19,7 +20,7 @@ export const initSentry = async (ctx: Context): Promise<void> => {
 
   Sentry.init({
     dsn: "https://0c26e0d8afd94e77a88ee1c3aa9e7065@o250689.ingest.sentry.io/6703266",
-    enabled: env.productionLike && (ctx.args["--telemetry"] ?? false),
+    enabled: env.productionLike && (args["--telemetry"] ?? false),
     release: packageJson.version,
     environment: packageJson.version.includes("experimental") ? "experimental" : "production",
   });
@@ -56,7 +57,6 @@ export const sendErrorToSentry = async (ctx: Context, error: GGTError): Promise<
       contexts: {
         ctx: {
           argv: process.argv,
-          args: ctx.args,
         },
         cause: error.cause ? serializeError(error.cause) : undefined,
         app: {

--- a/src/services/user/user.ts
+++ b/src/services/user/user.ts
@@ -90,7 +90,7 @@ export const getUserOrLogin = async (ctx: Context): Promise<User> => {
   });
 
   await confirm({ ensureEmptyLineAbove: true, content: "Would you like to log in?" });
-  await login(ctx);
+  await login(ctx, { _: [] });
 
   user = await getUser(ctx);
   assert(user, "missing user after successful login");


### PR DESCRIPTION
Similar to #1619, this removes more state from the context. The context doesn't need to know about the arguments.