### PR TITLE
Fix log line assertion error

### DIFF
--- a/.changeset/fix-empty-string-assertion-error.md
+++ b/.changeset/fix-empty-string-assertion-error.md
@@ -1,0 +1,13 @@
+---
+ggt: "patch"
+---
+
+Fix the following assertion error from occurring:
+
+```
+An error occurred while communicating with Gadget
+
+'' == true
+
+If you think this is a bug, click here to create an issue on GitHub.
+```

--- a/src/services/output/log/format/pretty.ts
+++ b/src/services/output/log/format/pretty.ts
@@ -4,7 +4,7 @@ import terminalLink from "terminal-link";
 import { type Environment } from "../../../app/app.js";
 
 import { config } from "../../../config/config.js";
-import { isObject } from "../../../util/is.js";
+import { isNil, isObject } from "../../../util/is.js";
 import { serializeObjectToHTTPQuery } from "../../../util/querystring.js";
 import colors from "../../colors.js";
 import { symbol } from "../../symbols.js";
@@ -47,7 +47,7 @@ const formatValue = (value: string, color: (s: string) => string, indent: number
 
   const buf: string[] = [];
   const firstLine = lines.shift();
-  assert(firstLine);
+  assert(!isNil(firstLine), "first line is nil");
   buf.push(color(firstLine));
 
   // color the rest of the lines


### PR DESCRIPTION
When we format the value of a log field, we split the value by new line, early return if the number of lines is 0, and assert the first line isn't null to make typescript happy:

```ts
const formatValue = (value: string, color: (s: string) => string, indent: number): string => {
  if (!value) {
    return EMPTY;
  }

  const lines = value.split(NEW_LINE);
  if (lines.length === 0) {
    return EMPTY;
  }

  const buf: string[] = [];
  const firstLine = lines.shift();
  assert(firstLine); // can't be null/undefined because we early return if lines.length === 0 above, but typescript doesn't know that so we assert here
  buf.push(color(firstLine));

  // ...
}
```

The issue with this is that `assert(firstLine)` will throw if `firstLine` is an empty string because an empty string is a falsy value 🤦‍♂️. This can be reproduced by logging a field with only a new line, e.g.

```ts
import { TestGlobalActionContext } from "gadget-server";

/**
 * @param { TestGlobalActionContext } context
 */
export async function run({ params, logger, api, connections }) {
  logger.info({ foo: "\n" }, "test");
};
```
Causes this:

```ts
  const lines = value.split(NEW_LINE); // ['', '']
  if (lines.length === 0) {
    return EMPTY;
  }

  const buf: string[] = [];
  const firstLine = lines.shift(); // ''
  assert(firstLine); // '' == true
```

```
An error occurred while communicating with Gadget

'' == true

If you think this is a bug, click here to create an issue on GitHub.
```


This PR fixes that by asserting that the firstLine is not nil, which is what I was originally trying to assert:

```ts
assert(!isNil(firstLine), "first line is nil");
```

---

The reason this ends up as a `ClientError` is because any errors thrown in the `onResponse` callback are passed to the `onError` callback which wraps all errors in a `ClientError`. We might want to change that...
- https://github.com/gadget-inc/ggt/blob/63e3a69b7b3e3ad3265e940a26f3fe2bb39202bc/src/services/app/client.ts#L133
- https://github.com/gadget-inc/ggt/blob/63e3a69b7b3e3ad3265e940a26f3fe2bb39202bc/src/services/app/client.ts#L130
- https://github.com/gadget-inc/ggt/blob/63e3a69b7b3e3ad3265e940a26f3fe2bb39202bc/src/services/filesync/filesync.ts#L347-L362

/cc @pistachiobaby 