### PR TITLE
Allow `ggt pull --from=production`

### DIFF
--- a/.changeset/ggt-pull-production.md
+++ b/.changeset/ggt-pull-production.md
@@ -1,0 +1,5 @@
+---
+ggt: minor
+---
+
+Allow `ggt pull --from=production` to pull files from your production environment.

--- a/spec/commands/__snapshots__/root.spec.ts.snap
+++ b/spec/commands/__snapshots__/root.spec.ts.snap
@@ -383,7 +383,7 @@ Usage
 
 Options
       -a, --app <app_name>           Selects the app to pull your environment changes from. Default set on ".gadget/sync.json"
-      --from, -e, --env <env_name>   Selects the environment to pull changes from. Default set on ".gadget/sync.json"
+      -e, --env, --from <env_name>   Selects the environment to pull changes from. Default set on ".gadget/sync.json"
       --force                        Forces a pull by discarding any changes made on your local directory since last sync
       --allow-different-directory    Pulls changes from any environment directory, even if the ".gadget/sync.json" file is missing
       --allow-different-app          Pulls changes to a different app using --app command, instead of the one in the “.gadget/sync.json” file
@@ -405,7 +405,7 @@ Usage
 
 Options
       -a, --app <app_name>           Selects the app to pull your environment changes from. Default set on ".gadget/sync.json"
-      --from, -e, --env <env_name>   Selects the environment to pull changes from. Default set on ".gadget/sync.json"
+      -e, --env, --from <env_name>   Selects the environment to pull changes from. Default set on ".gadget/sync.json"
       --force                        Forces a pull by discarding any changes made on your local directory since last sync
       --allow-different-directory    Pulls changes from any environment directory, even if the ".gadget/sync.json" file is missing
       --allow-different-app          Pulls changes to a different app using --app command, instead of the one in the “.gadget/sync.json” file
@@ -427,7 +427,7 @@ Usage
 
 Options
       -a, --app <app_name>           Selects the app to push local changes to. Default set on ".gadget/sync.json"
-      --from, -e, --env <env_name>   Selects the environment to push local changes to. Default set on ".gadget/sync.json"
+      -e, --env, --to <env_name>     Selects the environment to push local changes to. Default set on ".gadget/sync.json"
       --force                        Forces a push by discarding any changes made on your environment directory since last sync
       --allow-different-directory    Pushes changes from any local directory with existing files, even if the ".gadget/sync.json" file is missing
       --allow-different-app          Pushes changes to an app using --app command, instead of the one in the “.gadget/sync.json” file
@@ -449,7 +449,7 @@ Usage
 
 Options
       -a, --app <app_name>           Selects the app to push local changes to. Default set on ".gadget/sync.json"
-      --from, -e, --env <env_name>   Selects the environment to push local changes to. Default set on ".gadget/sync.json"
+      -e, --env, --to <env_name>     Selects the environment to push local changes to. Default set on ".gadget/sync.json"
       --force                        Forces a push by discarding any changes made on your environment directory since last sync
       --allow-different-directory    Pushes changes from any local directory with existing files, even if the ".gadget/sync.json" file is missing
       --allow-different-app          Pushes changes to an app using --app command, instead of the one in the “.gadget/sync.json” file

--- a/spec/commands/pull.spec.ts
+++ b/spec/commands/pull.spec.ts
@@ -327,4 +327,8 @@ describe("pull", () => {
 
     await expectLocalAndGadgetHashesMatch();
   });
+
+  // can't write these tests until makeSyncScenario supports multiple environments
+  it.todo("changes the environment when a different environment is specified");
+  it.todo("does not change the environment when the production environment is specified");
 });

--- a/spec/services/filesync/__snapshots__/sync-json.spec.ts.snap
+++ b/spec/services/filesync/__snapshots__/sync-json.spec.ts.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SyncJson.loadOrInit > does not allow --env=production when the command is "add" 1`] = `[Error: You cannot "ggt add" your production environment.]`;
+
+exports[`SyncJson.loadOrInit > does not allow --env=production when the command is "deploy" 1`] = `[Error: You cannot "ggt deploy" your production environment.]`;
+
+exports[`SyncJson.loadOrInit > does not allow --env=production when the command is "dev" 1`] = `[Error: You cannot "ggt dev" your production environment.]`;
+
+exports[`SyncJson.loadOrInit > does not allow --env=production when the command is "list" 1`] = `[Error: You cannot "ggt list" your production environment.]`;
+
+exports[`SyncJson.loadOrInit > does not allow --env=production when the command is "login" 1`] = `[Error: You cannot "ggt login" your production environment.]`;
+
+exports[`SyncJson.loadOrInit > does not allow --env=production when the command is "logout" 1`] = `[Error: You cannot "ggt logout" your production environment.]`;
+
+exports[`SyncJson.loadOrInit > does not allow --env=production when the command is "open" 1`] = `[Error: You cannot "ggt open" your production environment.]`;
+
+exports[`SyncJson.loadOrInit > does not allow --env=production when the command is "push" 1`] = `[Error: You cannot "ggt push" your production environment.]`;
+
+exports[`SyncJson.loadOrInit > does not allow --env=production when the command is "status" 1`] = `[Error: You cannot "ggt status" your production environment.]`;
+
+exports[`SyncJson.loadOrInit > does not allow --env=production when the command is "version" 1`] = `[Error: You cannot "ggt version" your production environment.]`;
+
+exports[`SyncJson.loadOrInit > does not allow --env=production when the command is "whoami" 1`] = `[Error: You cannot "ggt whoami" your production environment.]`;

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -9,6 +9,7 @@ export type PullArgs = typeof args;
 
 export const args = {
   ...SyncJsonArgs,
+  "--env": { type: String, alias: ["-e", "--environment", "--from"] },
   "--force": { type: Boolean, alias: "-f" },
 } satisfies ArgsDefinition;
 
@@ -24,7 +25,7 @@ export const usage: Usage = (_ctx) => {
 
   {gray Options}
         -a, --app <app_name>           Selects the app to pull your environment changes from. Default set on ".gadget/sync.json"
-        --from, -e, --env <env_name>   Selects the environment to pull changes from. Default set on ".gadget/sync.json"
+        -e, --env, --from <env_name>   Selects the environment to pull changes from. Default set on ".gadget/sync.json"
         --force                        Forces a pull by discarding any changes made on your local directory since last sync
         --allow-different-directory    Pulls changes from any environment directory, even if the ".gadget/sync.json" file is missing
         --allow-different-app          Pulls changes to a different app using --app command, instead of the one in the “.gadget/sync.json” file

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -9,6 +9,7 @@ export type PushArgs = typeof args;
 
 export const args = {
   ...SyncJsonArgs,
+  "--env": { type: String, alias: ["-e", "--environment", "--to"] },
   "--force": { type: Boolean, alias: "-f" },
 } satisfies ArgsDefinition;
 
@@ -24,7 +25,7 @@ export const usage: Usage = (_ctx) => {
 
   {gray Options}
         -a, --app <app_name>           Selects the app to push local changes to. Default set on ".gadget/sync.json"
-        --from, -e, --env <env_name>   Selects the environment to push local changes to. Default set on ".gadget/sync.json"
+        -e, --env, --to <env_name>     Selects the environment to push local changes to. Default set on ".gadget/sync.json"
         --force                        Forces a push by discarding any changes made on your environment directory since last sync
         --allow-different-directory    Pushes changes from any local directory with existing files, even if the ".gadget/sync.json" file is missing
         --allow-different-app          Pushes changes to an app using --app command, instead of the one in the “.gadget/sync.json” file

--- a/src/services/app/client.ts
+++ b/src/services/app/client.ts
@@ -156,7 +156,9 @@ export class Client {
   ): Promise<ExecutionResult<Operation["Data"], Operation["Extensions"]>> {
     let subdomain = this.environment.application.slug;
     if (this.environment.application.multiEnvironmentEnabled) {
-      subdomain += `--${this.environment.name}`;
+      if (this.environment.type !== "production") {
+        subdomain += `--${this.environment.name}`;
+      }
     } else if (this.environment.application.hasSplitEnvironments) {
       subdomain += "--development";
     }


### PR DESCRIPTION
This PR allows users to `ggt pull --from=production`.

When users run `ggt pull --env=<some-env>` today, their `.gadget/sync.json` updates to the specified environment, causing all future commands to happen on that environment. This doesn't make sense for the production environment though, because the only command that can be run against the production environment is `ggt pull`, so this PR makes ggt **not** update the `.gadget/sync.json` to the production environment when `ggt pull --from=production` is ran.