### PR TITLE
Backup one file at a time

### DIFF
--- a/.changeset/dest-already-exists.md
+++ b/.changeset/dest-already-exists.md
@@ -1,0 +1,5 @@
+---
+ggt: patch
+---
+
+Attempt to fix `Error: dest already exists.` by moving files one at a time to `.gadget/backup/`.


### PR DESCRIPTION
This is an attempt to fix the `Error: dest already exists.` issues that keep popping up.
- https://github.com/gadget-inc/ggt/issues/1819
- https://github.com/gadget-inc/ggt/issues/1851
- https://github.com/gadget-inc/ggt/issues/1853

While trying to reproduce this issue, I noticed the `Error: dest already exists.` error being logged when I deleted a model in Gadget's editor and then ran `ggt pull`. The error was happening while attempting to move deleted files into `.gadget/backup/`. The deleted files that failed to move into `.gadget/backup/` eventually succeeded because we wrap the move within a `pRetry`, so I didn't experience the final failure that causes ggt to crash.

I'm not sure how the file moves eventually succeeded because I didn't see the `"removing file in the way of backup path"` log line, which is how we typically recover from failing to move a file into `.gadget/backup/`... my current theory is that all of these issues are stemming from moving all the files in parallel, so this PR changes our file move logic to move all the files one at a time. After making this change, I didn't see any more `Error: dest already exists.` errors after deleting a model in Gadget's editor and running `ggt pull`.