### PR TITLE
Use --enable-source-maps and --keep-names

### DIFF
--- a/.changeset/enable-source-maps.md
+++ b/.changeset/enable-source-maps.md
@@ -1,0 +1,5 @@
+---
+ggt: patch
+---
+
+Enable source maps for better error messages and debugging.

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "/README.md"
   ],
   "scripts": {
-    "build": "pnpm run clean && esbuild src/main.ts --outdir=dist --format=esm --platform=node --target=node20 --inject:./shims/cjs.js --bundle --splitting --minify --sourcemap",
+    "build": "pnpm run clean && esbuild src/main.ts --outdir=dist --format=esm --platform=node --target=node20 --inject:./shims/cjs.js --bundle --splitting --minify --keep-names --sourcemap",
     "changeset": "changeset",
     "clean": "rimraf dist tmp/spec",
-    "dev": "pnpm run build --minify=false --watch",
+    "dev": "pnpm run build --minify=false --sources-content=false --watch",
     "generate:graphql": "graphql-codegen --config=graphql-codegen.yml",
     "lint": "concurrently 'npm:lint:*(!fix)' --group --names --prefix-colors=auto",
     "lint:cspell": "cspell . --no-progress --show-suggestions --show-context",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --enable-source-maps
 
 import { ggt } from "./ggt.js";
 


### PR DESCRIPTION
It's very difficult to figure out where an error was thrown when the stack trace looks like this:

```
Error: dest already exists.
	at Gm (dist/chunk-GIAIN3IJ.js:7:2753)
	at async tt.retries (dist/chunk-IPKFNVOS.js:175:708)
	at async I._fn (dist/chunk-IPKFNVOS.js:169:5410)
```

We're already outputting source maps, but we weren't telling node to use them 🤦.

This PR fixes that by passing `--enable-source-maps` to node when running ggt, which makes the line numbers point to the original `.ts` file. This PR also adds `--keep-names` to esbuild so that the function names in the stack trace are also correct.