### PR TITLE
Do not proceed if ggt runs in unsupported terminal environments

### DIFF
--- a/.changeset/gold-bikes-dance.md
+++ b/.changeset/gold-bikes-dance.md
@@ -1,0 +1,9 @@
+---
+"ggt": patch
+---
+
+Check the terminal environment before proceeding when running ggt
+
+We don't want to allow users to run `ggt` in places where terminal commands can be run in the Gadget editor.
+
+This change checks for special environment variables specific to Gadget and exits early if they are detected.

--- a/spec/ggt.spec.ts
+++ b/spec/ggt.spec.ts
@@ -1,5 +1,5 @@
 import { inspect } from "node:util";
-import { assert, beforeEach, describe, expect, it } from "vitest";
+import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 import * as root from "../src/commands/root.js";
 import { ggt } from "../src/ggt.js";
 import * as command from "../src/services/command/command.js";
@@ -11,6 +11,8 @@ import { PromiseSignal } from "../src/services/util/promise.js";
 import type { AnyFunction } from "../src/services/util/types.js";
 import { testCtx } from "./__support__/context.js";
 import { mock } from "./__support__/mock.js";
+import { expectStdout } from "./__support__/output.js";
+import { expectProcessExit } from "./__support__/process.js";
 
 describe("ggt", () => {
   beforeEach(() => {
@@ -45,5 +47,12 @@ describe("ggt", () => {
     onSignal!();
 
     await aborted;
+  });
+
+  it("exits early if running in the Gadget editor's terminal", async () => {
+    vi.stubEnv("GADGET_EDITOR_TERMINAL_SESSION_ID", "123");
+
+    await expectProcessExit(() => ggt(testCtx), 1);
+    expectStdout().toEqual("Running ggt in the Gadget editor's terminal is not supported.\n");
   });
 });

--- a/src/ggt.ts
+++ b/src/ggt.ts
@@ -10,6 +10,11 @@ import { activeSpinner, spin } from "./services/output/spinner.js";
 import { installJsonExtensions } from "./services/util/json.js";
 
 export const ggt = async (ctx = Context.init({ name: "ggt" })): Promise<void> => {
+  if (process.env["GADGET_EDITOR_TERMINAL_SESSION_ID"]) {
+    println("Running ggt in the Gadget editor's terminal is not supported.");
+    return process.exit(1);
+  }
+
   try {
     const rootArgs = parseArgs(root.args, { argv: process.argv.slice(2), permissive: true });
 


### PR DESCRIPTION
This PR introduces a check to make sure users are not running `ggt` in terminal environments that are not supported, for example, places that can run a terminal command in the Gadget editor.