### PR TITLE
Specify that https agents must use at least TLSv1.1

### DIFF
--- a/.changeset/tall-crabs-enjoy.md
+++ b/.changeset/tall-crabs-enjoy.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Restrict SSL/TLS to require TLSv1.1 or better. SSLv3 will no longer be supported.

--- a/src/services/http/http.ts
+++ b/src/services/http/http.ts
@@ -35,7 +35,10 @@ const getContext = (options: HttpOptions): Context => {
 export const http = got.extend({
   agent: {
     http: new HttpAgent({ keepAlive: true }),
-    https: new HttpsAgent({ keepAlive: true }),
+    https: new HttpsAgent({
+      keepAlive: true,
+      minVersion: "TLSv1.1",
+    }),
   },
   retry: {
     limit: 10,


### PR DESCRIPTION
Self explanatory. SSLv3 is obsolete, deprecated, and it looks like there are some bugged versions of OpenSSL floating around that can cause ggt to throw errors. While that is a fairly rare problem and OpenSSL updates are the real solution, we don't control client OpenSSL patching, and there's just not really any advantage to keeping SSLv3 support.