### PR TITLE
Adding pr template for changelogs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,5 @@
 ... a description that explains what, why, and how ...
 
-## 🎩 Instructions
-
-<someone> please :tophat::
-
-1. ...
-2. ...
-3. ...
-
-## PR Checklist
-
-- [ ] Important or complicated code is tested
-- [ ] Any user facing changes are documented (changelog section below)
-- [ ] Any app Problems are added to the problem finders
-- [ ] Any app data that needs a redeploy to take effect is listed in the `contentHash` functions
-- [ ] Important or complicated production behaviour has traces and logs added
-
 ## Changelog
 
 If this PR will affect change user-facing behaviour, add detailed information about the change here to prompt an AI generated changelog entry.


### PR DESCRIPTION
This will require that we have detailed changelog entries/descriptions in our PRs. Add [no-changelog-required] to the pr description (anywhere if the change doesn't need to be logged)