### PR TITLE
Misc fixes from telemetry

### DIFF
--- a/.changeset/beige-apples-greet.md
+++ b/.changeset/beige-apples-greet.md
@@ -1,0 +1,5 @@
+---
+"ggt": patch
+---
+
+Misc fixes from telemetry data, specifically including fixes for two bugs where expected app behaviour can wrongly display an unexpected error.

--- a/spec/commands/root.spec.ts
+++ b/spec/commands/root.spec.ts
@@ -74,6 +74,7 @@ describe("root", () => {
         login            Log in to your account
         logout           Log out of your account
         whoami           Print the currently logged in account
+        configure        Configure default execution options
         version          Print this version of ggt
 
       Flags

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -39,6 +39,7 @@ export const usage: Usage = () => {
       login            Log in to your account
       logout           Log out of your account
       whoami           Print the currently logged in account
+      configure        Configure default execution options
       version          Print this version of ggt
 
     {gray Flags}

--- a/src/services/app/edit/edit.ts
+++ b/src/services/app/edit/edit.ts
@@ -114,7 +114,7 @@ export class Edit {
     if (response.errors) {
       /* If it is the specific unauthenticated error, handle it differently as nothing is broken in that case */
       if (isStringArray(response.errors) && response.errors[0] && response.errors[0] === "Unauthenticated. No authenticated client.") {
-        throw new AuthenticationError();
+        throw new AuthenticationError(mutation);
       }
       throw new ClientError(mutation, response.errors);
     }

--- a/src/services/http/http.ts
+++ b/src/services/http/http.ts
@@ -8,7 +8,6 @@ import { config } from "../config/config.js";
 import { sprint } from "../output/sprint.js";
 import { writeSession } from "../user/session.js";
 import { serializeError } from "../util/object.js";
-import { isGadgetServicesRequest } from "./auth.js";
 
 export type HttpOptions = OptionsInit;
 
@@ -115,7 +114,7 @@ export const http = got.extend({
           },
         });
 
-        if (response.statusCode === 401 && isGadgetServicesRequest(response.request.options)) {
+        if (response.statusCode === 401) {
           // clear the session if the request was unauthorized
           writeSession(ctx, undefined);
         }

--- a/src/services/output/log/format/json.ts
+++ b/src/services/output/log/format/json.ts
@@ -3,7 +3,12 @@ import { isObject, isString } from "../../../util/is.js";
 import type { Formatter } from "./format.js";
 
 export const formatJson: Formatter = (level, name, msg, fields) => {
-  return JSON.stringify({ level, name, msg: stripAnsi(msg).trim(), fields: serializeFields(fields) }) + "\n";
+  if (msg) {
+    msg = stripAnsi(msg).trim();
+  } else {
+    msg = "";
+  }
+  return JSON.stringify({ level, name, msg, fields: serializeFields(fields) }) + "\n";
 };
 
 const serializeFields = (fields: Record<string, unknown>): Record<string, unknown> => {

--- a/src/services/util/is.ts
+++ b/src/services/util/is.ts
@@ -24,7 +24,7 @@ export const isFunction = (val: unknown): val is Function => {
 
 export const isStringArray = (val: unknown): val is string[] => {
   return z.array(z.string()).safeParse(val).success;
-}
+};
 
 export const isError = (val: unknown): val is Error => {
   return val instanceof Error;

--- a/src/services/util/is.ts
+++ b/src/services/util/is.ts
@@ -22,6 +22,10 @@ export const isFunction = (val: unknown): val is Function => {
   return typeof val === "function";
 };
 
+export const isStringArray = (val: unknown): val is string[] => {
+  return z.array(z.string()).safeParse(val).success;
+}
+
 export const isError = (val: unknown): val is Error => {
   return val instanceof Error;
 };


### PR DESCRIPTION
Now that we prompt for default options including sending telemetry and crash data as our recomended default, we have been able to trace some issues. First, when authentication expires after a command is already running it comes through it a format we weren't accounting for which resulted in ggt crashing instead of a clean exit with a prompt to sign in again. Another instance, it is possible for the json output setup to encounter an undefined which it would not convert to an empty string as with regular text, and it would instead crash.

## Changelog

Assorted fixes for some issues that were seen via app telemetry/crash reporting
