### PR TITLE
Make ggt push retry "Files version mismatch" errors

### DIFF
--- a/.changeset/push-fvmm.md
+++ b/.changeset/push-fvmm.md
@@ -1,0 +1,5 @@
+---
+ggt: patch
+---
+
+Make `ggt push` retry "Files version mismatch" errors when possible.

--- a/spec/services/filesync/error.spec.ts
+++ b/spec/services/filesync/error.spec.ts
@@ -8,6 +8,7 @@ import type { Command } from "../../../src/services/command/command.js";
 import { Directory } from "../../../src/services/filesync/directory.js";
 import {
   TooManyMergeAttemptsError,
+  TooManyPushAttemptsError,
   UnknownDirectoryError,
   YarnNotFoundError,
   isFilesVersionMismatchError,
@@ -78,6 +79,23 @@ describe(TooManyMergeAttemptsError.name, () => {
       but your local and environment's files still don't match.
 
       Make sure no one else is editing files on your environment, and try again.
+
+      If you think this is a bug, use the link below to create an issue on GitHub.
+
+      https://github.com/gadget-inc/ggt/issues/new?template=bug_report.yml&error-id=00000000-0000-0000-0000-000000000000
+      "
+    `);
+  });
+});
+
+describe(TooManyPushAttemptsError.name, () => {
+  it("renders correctly", () => {
+    const error = new TooManyPushAttemptsError(10, "push");
+    expect(error.sprint()).toMatchInlineSnapshot(`
+      "We tried to push your local changes to your environment 10 times,
+      but your environment's files kept changing since we last checked.
+
+      Please re-run "ggt push" to see the changes and try again.
 
       If you think this is a bug, use the link below to create an issue on GitHub.
 

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -104,14 +104,14 @@ export const run: Run<AddArgs> = async (ctx, args) => {
   }
 
   const filesync = new FileSync(syncJson);
-  const hashes = await filesync.hashes(ctx, true);
+  const hashes = await filesync.hashes(ctx, { silent: true });
 
   if (!hashes.inSync) {
     await filesync.merge(ctx, {
       hashes,
       printEnvironmentChangesOptions: { limit: 5 },
       printLocalChangesOptions: { limit: 5 },
-      quietly: true,
+      silent: true,
     });
   }
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -90,14 +90,12 @@ export const run: Run<DeployArgs> = async (ctx, args) => {
         switch (true) {
           case hashes.bothChanged:
             content = sprint`Would you like to push your local changes and {underline discard your environment's} changes now?`;
-            args["--force"] = true; // accepting this confirmation implies --force
             break;
           case hashes.localChangesToPush.size > 0:
             content = sprint`Would you like to push your local changes now?`;
             break;
           case hashes.environmentChanges.size > 0:
             content = sprint`Do you want to {underline discard your environment's} changes now?`;
-            args["--force"] = true; // same as above
             break;
           default:
             unreachable("no changes to push or discard");
@@ -114,7 +112,7 @@ export const run: Run<DeployArgs> = async (ctx, args) => {
       }
     }
 
-    await filesync.push(ctx, { command: "deploy", hashes, force: args["--force"] });
+    await filesync.push(ctx, { command: "deploy", hashes });
   }
 
   const variables = {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -172,7 +172,7 @@ export const run: Run<DevArgs> = async (ctx, args) => {
           await filesync.merge(ctx, { hashes });
           break;
         case FileSyncStrategy.PUSH:
-          await filesync.push(ctx, { command: "dev", hashes, force: true });
+          await filesync.push(ctx, { command: "dev", hashes });
           break;
         case FileSyncStrategy.PULL:
           await filesync.pull(ctx, { hashes, force: true });

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -2,6 +2,7 @@ import { ArgError, type ArgsDefinition } from "../services/command/arg.js";
 import type { Run, Usage } from "../services/command/command.js";
 import { FileSync } from "../services/filesync/filesync.js";
 import { SyncJson, SyncJsonArgs, loadSyncJsonDirectory } from "../services/filesync/sync-json.js";
+import { confirm } from "../services/output/confirm.js";
 import { println } from "../services/output/print.js";
 import { sprint } from "../services/output/sprint.js";
 
@@ -58,10 +59,18 @@ export const run: Run<typeof args> = async (ctx, args) => {
     return;
   }
 
-  if (hashes.environmentChangesToPull.size > 0 && !hashes.onlyDotGadgetFilesChanged) {
+  if (hashes.environmentChanges.size > 0 && !hashes.onlyDotGadgetFilesChanged) {
     // show them the environment changes they will discard
     await filesync.print(ctx, { hashes });
+
+    if (!args["--force"]) {
+      // they didn't pass --force, so we need to ask them if they want to discard the environment changes
+      await confirm({
+        ensureEmptyLineAbove: true,
+        content: sprint`Are you sure you want to {underline discard} your environment's changes?`,
+      });
+    }
   }
 
-  await filesync.push(ctx, { command: "push", hashes, force: args["--force"] });
+  await filesync.push(ctx, { command: "push", hashes });
 };

--- a/src/services/filesync/error.ts
+++ b/src/services/filesync/error.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import pluralize from "pluralize";
 import { ClientError } from "../app/error.js";
 import { type Command } from "../command/command.js";
 import type { Context } from "../command/context.js";
@@ -93,6 +94,26 @@ export class TooManyMergeAttemptsError extends GGTError {
       but your local and environment's files still don't match.
 
       Make sure no one else is editing files on your environment, and try again.
+    `;
+  }
+}
+
+export class TooManyPushAttemptsError extends GGTError {
+  isBug = IsBug.MAYBE;
+
+  constructor(
+    readonly attempts: number,
+    readonly command: Command,
+  ) {
+    super(`Failed to push local changes to environment after ${pluralize("attempt", attempts, true)}.`);
+  }
+
+  protected render(): string {
+    return sprint`
+      We tried to push your local changes to your environment ${pluralize("time", this.attempts, true)},
+      but your environment's files kept changing since we last checked.
+
+      Please re-run "ggt ${this.command}" to see the changes and try again.
     `;
   }
 }


### PR DESCRIPTION
closes GGT-9274

Aurelien is running into "Files version mismatch" errors when running `ggt push`. The "Files version mismatch" error is thrown when either:
- ggt expects the environment's files version to be at `N` but by the time the environment receives the files it's at files version `N + 1`.
- the files version returned from the environment after it has received the pushed files is greater than ggt's current files version + 1.

`ggt dev` handles "Files version mismatch" errors by pulling down the files that changed on the environment and pushing the local files again, but `ggt push` isn't allowed to pull files so it can't handle this error the same way.

This PR implements the 2 scenarios where `ggt push` can gracefully handle "Files version mismatch" errors without having to pull.
1. If the environment's `N + 1` files version change only changed `.gadget/` files, then `ggt push` can retry without the risk of overwriting the `N + 1` changes because `.gadget/` files cannot be changed by `ggt push`. `.gadget/` files are owned by Gadget and ggt filters out local `.gadget/` changes before pushing.
1. If the files version that the environment returned is greater than ggt's current files version + 1, then that means the files were pushed successfully, but other file changes were happening on the environment at the same time. Since the files were pushed successfully, we should treat this as a successful push and swallow the error.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Retries `ggt push` on "Files version mismatch" when safe (.gadget/ changes or remote advanced), introduces TooManyPushAttemptsError, and updates command flows and hashes API.
> 
> - **Filesync**:
>   - **Push retries**: `FileSync.push` now retries on `Files version mismatch` when only `.gadget/` files changed; treats remote filesVersion > expected+1 as success; otherwise throws `EdgeCaseError`; caps attempts with new `MAX_PUSH_ATTEMPTS` and `TooManyPushAttemptsError`.
>   - **API tweaks**: `hashes(ctx, { silent })` replaces `quietly`; `merge` option `quietly` → `silent`.
>   - **Errors**: Add `TooManyPushAttemptsError`; use `pluralize`; extend `isFilesVersionMismatchError` handling/`swallowFilesVersionMismatch` usage.
> - **Commands**:
>   - `push`: show env changes, confirm discard unless `--force`, then call `filesync.push` (no `force` arg); consider `hashes.environmentChanges` (not just `...ToPull`).
>   - `deploy`/`dev`: stop passing `force` to `push`; keep confirmation in deploy as needed.
>   - `add`: call `hashes({ silent: true })` and `merge({ silent: true })`.
> - **Tests**:
>   - Add/adjust specs for push retry scenarios, success on last attempt, `.gadget/`-only changes, non-`.gadget/` edge case, and new error rendering.
> - **Changeset**: document patch release for `ggt push` retry behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6bdf73dd2f27c15b2f66db241bf530f9a97ef6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->