### PR TITLE
Require Node.js 20

### DIFF
--- a/.changeset/node-20.md
+++ b/.changeset/node-20.md
@@ -1,0 +1,14 @@
+---
+ggt: major
+---
+
+Require Node.js 20 or later.
+
+Node.js 18 reached End-of-Life (EOL) on 2025-04-30:
+
+- https://github.com/nodejs/release#end-of-life-releases
+- https://nodejs.org/en/blog/announcements/node-18-eol-support
+
+This means Node.js 18 no longer receives security updates and bug fixes.
+
+ggt runs on your computer, so it's important to use a supported version of Node to ensure you have the latest security updates. **Your Gadget environment will continue to use the Node version specified in your [Framework version](https://docs.gadget.dev/guides/gadget-framework).**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,12 +14,6 @@ updates:
       - dependency-name: "@types/node" # manually updated
         update-types:
           - "version-update:semver-major"
-      - dependency-name: "cli-spinners" # requires node >= 18.20, but ggt supports >= 18.0
-        update-types:
-          - "version-update:semver-major"
-      - dependency-name: "execa" # requires node >= 18.18, but ggt supports >= 18.0
-        update-types:
-          - "version-update:semver-major"
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: pnpm
 
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: pnpm
 
       - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: pnpm
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -476,7 +476,6 @@
 - c783efa: Fix `TooManySyncAttemptsError` when local directory's permissions don't match Gadget's
 - 340a5de: Fix errors serializing `bigint`s when `--json` is passed
 - 3de43d1: Logging improvements:
-
   - No longer truncating arrays in logs when `--json` is passed
   - Now truncating objects in logs unless log level is trace
   - Showing number of truncated elements/properties when arrays/objects are truncated
@@ -738,7 +737,6 @@
 - b110061: Bump @oclif/plugin-warn-if-update-available from 2.0.42 to 2.0.44
 - c482369: Bump @oclif/plugin-not-found from 2.3.27 to 2.3.28
 - ee23711: Improve sentry integration
-
   - Added sentry breadcrumbs to help debug on-going bugs.
   - Added ability to disable sentry via `GGT_SENTRY_ENABLED=false`
 

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721016451,
-        "narHash": "sha256-Cypl9ORr5UjtBsbjXMTJRepTe362yNVrPrntUvHiTaw=",
+        "lastModified": 1761656231,
+        "narHash": "sha256-EiED5k6gXTWoAIS8yQqi5mAX6ojnzpHwAQTS3ykeYMg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a14c5d651cee9ed70f9cd9e83f323f1e531002db",
+        "rev": "e99366c665bdd53b7b500ccdc5226675cfc51f45",
         "type": "github"
       },
       "original": {

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -19,7 +19,7 @@
           mkcert = pkgs.mkcert;
           nix-direnv = pkgs.nix-direnv;
           nixpkgs-fmt = pkgs.nixpkgs-fmt;
-          nodejs = pkgs.nodejs-18_x;
+          nodejs = pkgs.nodejs_20;
           yarn = pkgs.yarn.override { nodejs = flake.packages.nodejs; };
 
           ggt = pkgs.writeShellScriptBin "ggt" ''

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "release": "pnpm run build && changeset publish",
     "test": "vitest --cache",
     "test:watch": "pnpm run test --watch",
-    "version": "changeset version && node --loader=ts-node/esm --no-warnings scripts/generate-readme.ts"
+    "version": "changeset version && prettier --write CHANGELOG.md && node --loader=ts-node/esm --no-warnings scripts/generate-readme.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.4",
@@ -55,7 +55,7 @@
     "@types/fast-levenshtein": "^0.0.4",
     "@types/fs-extra": "^11.0.4",
     "@types/ms": "^2.1.0",
-    "@types/node": "^18.19.101",
+    "@types/node": "^20.19.24",
     "@types/node-notifier": "^8.0.5",
     "@types/normalize-package-data": "^2.4.4",
     "@types/normalize-path": "^3.0.2",
@@ -140,6 +140,6 @@
   },
   "packageManager": "pnpm@8.12.0",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ devDependencies:
     version: 5.0.3(graphql@16.11.0)
   '@graphql-codegen/cli':
     specifier: ^5.0.4
-    version: 5.0.4(@types/node@18.19.101)(graphql-sock@1.0.1)(graphql@16.11.0)(typescript@5.7.3)
+    version: 5.0.4(@types/node@20.19.24)(graphql-sock@1.0.1)(graphql@16.11.0)(typescript@5.7.3)
   '@graphql-codegen/typescript':
     specifier: ^4.1.3
     version: 4.1.3(graphql@16.11.0)
@@ -36,8 +36,8 @@ devDependencies:
     specifier: ^2.1.0
     version: 2.1.0
   '@types/node':
-    specifier: ^18.19.101
-    version: 18.19.101
+    specifier: ^20.19.24
+    version: 20.19.24
   '@types/node-notifier':
     specifier: ^8.0.5
     version: 8.0.5
@@ -259,7 +259,7 @@ devDependencies:
     version: 2.2.0
   ts-node:
     specifier: ^10.9.2
-    version: 10.9.2(@types/node@18.19.101)(typescript@5.7.3)
+    version: 10.9.2(@types/node@20.19.24)(typescript@5.7.3)
   type-fest:
     specifier: ^4.41.0
     version: 4.41.0
@@ -268,7 +268,7 @@ devDependencies:
     version: 5.7.3
   vitest:
     specifier: ^3.1.4
-    version: 3.1.4(@types/node@18.19.101)
+    version: 3.1.4(@types/node@20.19.24)
   watcher:
     specifier: ^2.3.1
     version: 2.3.1
@@ -1400,7 +1400,7 @@ packages:
       tslib: 2.6.3
     dev: true
 
-  /@graphql-codegen/cli@5.0.4(@types/node@18.19.101)(graphql-sock@1.0.1)(graphql@16.11.0)(typescript@5.7.3):
+  /@graphql-codegen/cli@5.0.4(@types/node@20.19.24)(graphql-sock@1.0.1)(graphql@16.11.0)(typescript@5.7.3):
     resolution: {integrity: sha512-vPO1mCtrttFVy8mPR+jMAvsYTv8E/7payIPaneeGE15mQjyvQXXsHoAg06Qpf6tykOdCwKVLWre0Mf6g0KBwUg==}
     engines: {node: '>=16'}
     hasBin: true
@@ -1420,12 +1420,12 @@ packages:
       '@graphql-tools/apollo-engine-loader': 8.0.13(graphql@16.11.0)
       '@graphql-tools/code-file-loader': 8.1.13(graphql@16.11.0)
       '@graphql-tools/git-loader': 8.0.17(graphql@16.11.0)
-      '@graphql-tools/github-loader': 8.0.13(@types/node@18.19.101)(graphql@16.11.0)
+      '@graphql-tools/github-loader': 8.0.13(@types/node@20.19.24)(graphql@16.11.0)
       '@graphql-tools/graphql-file-loader': 8.0.12(graphql@16.11.0)
       '@graphql-tools/json-file-loader': 8.0.11(graphql@16.11.0)
       '@graphql-tools/load': 8.0.12(graphql@16.11.0)
-      '@graphql-tools/prisma-loader': 8.0.17(@types/node@18.19.101)(graphql@16.11.0)
-      '@graphql-tools/url-loader': 8.0.24(@types/node@18.19.101)(graphql@16.11.0)
+      '@graphql-tools/prisma-loader': 8.0.17(@types/node@20.19.24)(graphql@16.11.0)
+      '@graphql-tools/url-loader': 8.0.24(@types/node@20.19.24)(graphql@16.11.0)
       '@graphql-tools/utils': 10.7.2(graphql@16.11.0)
       '@whatwg-node/fetch': 0.10.3
       chalk: 4.1.2
@@ -1433,7 +1433,7 @@ packages:
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 16.11.0
-      graphql-config: 5.1.3(@types/node@18.19.101)(graphql@16.11.0)(typescript@5.7.3)
+      graphql-config: 5.1.3(@types/node@20.19.24)(graphql@16.11.0)(typescript@5.7.3)
       inquirer: 8.2.6
       is-glob: 4.0.3
       jiti: 1.21.7
@@ -1759,7 +1759,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@graphql-tools/executor-http@1.2.6(@types/node@18.19.101)(graphql@16.11.0):
+  /@graphql-tools/executor-http@1.2.6(@types/node@20.19.24)(graphql@16.11.0):
     resolution: {integrity: sha512-D+gcyDlqKFiwVEubf9HxNijG7LAck0ApXypv/oBzBIOt7avy+PkNopcjSikxy0BvxkIfyjaAtnYlmgf4kC6Y8g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -1772,7 +1772,7 @@ packages:
       '@whatwg-node/fetch': 0.10.3
       extract-files: 11.0.0
       graphql: 16.11.0
-      meros: 1.3.0(@types/node@18.19.101)
+      meros: 1.3.0(@types/node@20.19.24)
       tslib: 2.8.1
       value-or-promise: 1.0.12
     transitivePeerDependencies:
@@ -1828,13 +1828,13 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-tools/github-loader@8.0.13(@types/node@18.19.101)(graphql@16.11.0):
+  /@graphql-tools/github-loader@8.0.13(@types/node@20.19.24)(graphql@16.11.0):
     resolution: {integrity: sha512-1eaRdfLFniIhs+MAHGDwy5Q6KraPRd48XHUV+HDuD63LHi10JtxVBPTWSUgNUkPkW0XoReyISjx9NFgTPK423A==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/executor-http': 1.2.6(@types/node@18.19.101)(graphql@16.11.0)
+      '@graphql-tools/executor-http': 1.2.6(@types/node@20.19.24)(graphql@16.11.0)
       '@graphql-tools/graphql-tag-pluck': 8.3.12(graphql@16.11.0)
       '@graphql-tools/utils': 10.7.2(graphql@16.11.0)
       '@whatwg-node/fetch': 0.10.3
@@ -1938,13 +1938,13 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@graphql-tools/prisma-loader@8.0.17(@types/node@18.19.101)(graphql@16.11.0):
+  /@graphql-tools/prisma-loader@8.0.17(@types/node@20.19.24)(graphql@16.11.0):
     resolution: {integrity: sha512-fnuTLeQhqRbA156pAyzJYN0KxCjKYRU5bz1q/SKOwElSnAU4k7/G1kyVsWLh7fneY78LoMNH5n+KlFV8iQlnyg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/url-loader': 8.0.24(@types/node@18.19.101)(graphql@16.11.0)
+      '@graphql-tools/url-loader': 8.0.24(@types/node@20.19.24)(graphql@16.11.0)
       '@graphql-tools/utils': 10.7.2(graphql@16.11.0)
       '@types/js-yaml': 4.0.9
       '@whatwg-node/fetch': 0.10.3
@@ -2010,14 +2010,14 @@ packages:
       value-or-promise: 1.0.12
     dev: true
 
-  /@graphql-tools/url-loader@8.0.24(@types/node@18.19.101)(graphql@16.11.0):
+  /@graphql-tools/url-loader@8.0.24(@types/node@20.19.24)(graphql@16.11.0):
     resolution: {integrity: sha512-f+Yt6sswiEPrcWsInMbmf+3HNENV2IZK1z3IiGMHuyqb+QsMbJLxzDPHnxMtF2QGJOiRjBQy2sF2en7DPG+jSw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-tools/executor-graphql-ws': 1.3.7(graphql@16.11.0)
-      '@graphql-tools/executor-http': 1.2.6(@types/node@18.19.101)(graphql@16.11.0)
+      '@graphql-tools/executor-http': 1.2.6(@types/node@20.19.24)(graphql@16.11.0)
       '@graphql-tools/executor-legacy-ws': 1.1.10(graphql@16.11.0)
       '@graphql-tools/utils': 10.7.2(graphql@16.11.0)
       '@graphql-tools/wrap': 10.0.29(graphql@16.11.0)
@@ -2951,7 +2951,7 @@ packages:
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
     dev: true
 
   /@types/debug@4.1.12:
@@ -2990,7 +2990,7 @@ packages:
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
     dev: true
 
   /@types/http-cache-semantics@4.0.4:
@@ -3012,7 +3012,7 @@ packages:
   /@types/jsonfile@6.1.4:
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
     dependencies:
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
     dev: true
 
   /@types/mdast@4.0.4:
@@ -3028,23 +3028,23 @@ packages:
   /@types/mysql@2.15.26:
     resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
     dependencies:
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
     dev: true
 
   /@types/node-notifier@8.0.5:
     resolution: {integrity: sha512-LX7+8MtTsv6szumAp6WOy87nqMEdGhhry/Qfprjm1Ma6REjVzeF7SCyvPtp5RaF6IkXCS9V4ra8g5fwvf2ZAYg==}
     dependencies:
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
     dev: true
 
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node@18.19.101:
-    resolution: {integrity: sha512-Ykg7fcE3+cOQlLUv2Ds3zil6DVjriGQaSN/kEpl5HQ3DIGM6W0F2n9+GkWV4bRt7KjLymgzNdTnSKCbFUUJ7Kw==}
+  /@types/node@20.19.24:
+    resolution: {integrity: sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==}
     dependencies:
-      undici-types: 5.26.5
+      undici-types: 6.21.0
     dev: true
 
   /@types/normalize-package-data@2.4.4:
@@ -3064,7 +3064,7 @@ packages:
   /@types/pg@8.6.1:
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
     dependencies:
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
       pg-protocol: 1.10.0
       pg-types: 2.2.0
     dev: true
@@ -3084,7 +3084,7 @@ packages:
   /@types/set-cookie-parser@2.4.10:
     resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
     dependencies:
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
     dev: true
 
   /@types/shimmer@1.2.0:
@@ -3094,7 +3094,7 @@ packages:
   /@types/tedious@4.0.14:
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
     dependencies:
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
     dev: true
 
   /@types/ungap__structured-clone@1.2.0:
@@ -3112,7 +3112,7 @@ packages:
   /@types/ws@8.5.14:
     resolution: {integrity: sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==}
     dependencies:
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
     dev: true
 
   /@typescript-eslint/eslint-plugin@8.11.0(@typescript-eslint/parser@8.11.0)(eslint@8.57.1)(typescript@5.7.3):
@@ -3411,7 +3411,7 @@ packages:
       '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
-      vite: 6.3.5(@types/node@18.19.101)
+      vite: 6.3.5(@types/node@20.19.24)
     dev: true
 
   /@vitest/pretty-format@3.1.4:
@@ -5561,7 +5561,7 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
-  /graphql-config@5.1.3(@types/node@18.19.101)(graphql@16.11.0)(typescript@5.7.3):
+  /graphql-config@5.1.3(@types/node@20.19.24)(graphql@16.11.0)(typescript@5.7.3):
     resolution: {integrity: sha512-RBhejsPjrNSuwtckRlilWzLVt2j8itl74W9Gke1KejDTz7oaA5kVd6wRn9zK9TS5mcmIYGxf7zN7a1ORMdxp1Q==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
@@ -5575,7 +5575,7 @@ packages:
       '@graphql-tools/json-file-loader': 8.0.11(graphql@16.11.0)
       '@graphql-tools/load': 8.0.12(graphql@16.11.0)
       '@graphql-tools/merge': 9.0.17(graphql@16.11.0)
-      '@graphql-tools/url-loader': 8.0.24(@types/node@18.19.101)(graphql@16.11.0)
+      '@graphql-tools/url-loader': 8.0.24(@types/node@20.19.24)(graphql@16.11.0)
       '@graphql-tools/utils': 10.7.2(graphql@16.11.0)
       cosmiconfig: 8.3.6(typescript@5.7.3)
       graphql: 16.11.0
@@ -6596,7 +6596,7 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /meros@1.3.0(@types/node@18.19.101):
+  /meros@1.3.0(@types/node@20.19.24):
     resolution: {integrity: sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==}
     engines: {node: '>=13'}
     peerDependencies:
@@ -6605,7 +6605,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
     dev: true
 
   /micromark-core-commonmark@2.0.2:
@@ -8504,7 +8504,7 @@ packages:
     resolution: {integrity: sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==}
     dev: true
 
-  /ts-node@10.9.2(@types/node@18.19.101)(typescript@5.7.3):
+  /ts-node@10.9.2(@types/node@20.19.24)(typescript@5.7.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -8523,7 +8523,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
       acorn: 8.12.1
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -8658,8 +8658,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+  /undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
     dev: true
 
   /unicorn-magic@0.1.0:
@@ -8831,7 +8831,7 @@ packages:
       vfile-message: 4.0.2
     dev: true
 
-  /vite-node@3.1.4(@types/node@18.19.101):
+  /vite-node@3.1.4(@types/node@20.19.24):
     resolution: {integrity: sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -8840,7 +8840,7 @@ packages:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@18.19.101)
+      vite: 6.3.5(@types/node@20.19.24)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8856,7 +8856,7 @@ packages:
       - yaml
     dev: true
 
-  /vite@6.3.5(@types/node@18.19.101):
+  /vite@6.3.5(@types/node@20.19.24):
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -8896,7 +8896,7 @@ packages:
       yaml:
         optional: true
     dependencies:
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
       esbuild: 0.25.0
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
@@ -8907,7 +8907,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@3.1.4(@types/node@18.19.101):
+  /vitest@3.1.4(@types/node@20.19.24):
     resolution: {integrity: sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -8935,7 +8935,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 18.19.101
+      '@types/node': 20.19.24
       '@vitest/expect': 3.1.4
       '@vitest/mocker': 3.1.4(vite@6.3.5)
       '@vitest/pretty-format': 3.1.4
@@ -8954,8 +8954,8 @@ packages:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@18.19.101)
-      vite-node: 3.1.4(@types/node@18.19.101)
+      vite: 6.3.5(@types/node@20.19.24)
+      vite-node: 3.1.4(@types/node@20.19.24)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
This bumps our minimum supported version of Node.js from 18 -> 20.

Node.js 18 reached End-of-Life (EOL) on 2025-04-30:

- https://github.com/nodejs/release#end-of-life-releases
- https://nodejs.org/en/blog/announcements/node-18-eol-support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raise minimum Node.js to 20 and update CI, Nix, and dependencies to match.
> 
> - **BREAKING**:
>   - Require Node.js `>=20` via `package.json#engines` and add a changeset (`.changeset/node-20.md`).
> - **CI/CD**:
>   - Switch GitHub Actions workflows (`.github/workflows/ci.yml`, `cd.yml`) to Node `20` for lint, build, test, and release.
> - **Dev Environment (Nix)**:
>   - Use `nodejs_20` in `nix/flake.nix` and update `nix/flake.lock` inputs.
> - **Dependencies/Tooling**:
>   - Bump `@types/node` to `^20` and refresh `pnpm-lock.yaml` accordingly.
>   - Tweak `version` script to run `prettier --write CHANGELOG.md`.
>   - Clean up Dependabot config: keep `@types/node` major updates ignored; remove other ignores.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 075a7ab0660fc7713b983aef655053084ee260cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->