### PR TITLE
Remove `.gadget/backup/` directory

### DIFF
--- a/.changeset/remove-backup.md
+++ b/.changeset/remove-backup.md
@@ -1,0 +1,11 @@
+---
+ggt: major
+---
+
+Remove the `.gadget/backup/` directory.
+
+`ggt` will now permanently delete files from the local filesystem when receiving a “delete file” event, rather than moving them to `.gadget/backup/`.
+
+The `.gadget/backup/` directory was introduced in v0.2.0, before Gadget supported git and source control, as a recovery mechanism for accidental deletions. However, it did not capture changes from “update file” events and became a frequent source of bugs.
+
+Since local editors and source control now handle file recovery more reliably, this change removes the `.gadget/backup/` directory to simplify the codebase and reduce maintenance issues.

--- a/spec/commands/dev.spec.ts
+++ b/spec/commands/dev.spec.ts
@@ -131,34 +131,32 @@ describe("dev", () => {
     await waitUntilLocalFilesVersion(4n);
 
     await expectDirs().resolves.toMatchInlineSnapshot(`
-        {
-          "filesVersionDirs": {
-            "1": {
-              ".gadget/": "",
-            },
-            "2": {
-              ".gadget/": "",
-              "file.txt": "file v2",
-            },
-            "3": {
-              ".gadget/": "",
-              "file.txt": "file v3",
-            },
-            "4": {
-              ".gadget/": "",
-            },
-          },
-          "gadgetDir": {
+      {
+        "filesVersionDirs": {
+          "1": {
             ".gadget/": "",
           },
-          "localDir": {
+          "2": {
             ".gadget/": "",
-            ".gadget/backup/": "",
-            ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"4"}}}",
+            "file.txt": "file v2",
           },
-        }
-      `);
+          "3": {
+            ".gadget/": "",
+            "file.txt": "file v3",
+          },
+          "4": {
+            ".gadget/": "",
+          },
+        },
+        "gadgetDir": {
+          ".gadget/": "",
+        },
+        "localDir": {
+          ".gadget/": "",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"4"}}}",
+        },
+      }
+    `);
 
     // receive a new directory
     await emitGadgetChanges({
@@ -170,40 +168,38 @@ describe("dev", () => {
     await waitUntilLocalFilesVersion(5n);
 
     await expectDirs().resolves.toMatchInlineSnapshot(`
-        {
-          "filesVersionDirs": {
-            "1": {
-              ".gadget/": "",
-            },
-            "2": {
-              ".gadget/": "",
-              "file.txt": "file v2",
-            },
-            "3": {
-              ".gadget/": "",
-              "file.txt": "file v3",
-            },
-            "4": {
-              ".gadget/": "",
-            },
-            "5": {
-              ".gadget/": "",
-              "directory/": "",
-            },
+      {
+        "filesVersionDirs": {
+          "1": {
+            ".gadget/": "",
           },
-          "gadgetDir": {
+          "2": {
+            ".gadget/": "",
+            "file.txt": "file v2",
+          },
+          "3": {
+            ".gadget/": "",
+            "file.txt": "file v3",
+          },
+          "4": {
+            ".gadget/": "",
+          },
+          "5": {
             ".gadget/": "",
             "directory/": "",
           },
-          "localDir": {
-            ".gadget/": "",
-            ".gadget/backup/": "",
-            ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"5"}}}",
-            "directory/": "",
-          },
-        }
-      `);
+        },
+        "gadgetDir": {
+          ".gadget/": "",
+          "directory/": "",
+        },
+        "localDir": {
+          ".gadget/": "",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"5"}}}",
+          "directory/": "",
+        },
+      }
+    `);
 
     // receive a delete to a directory
     await emitGadgetChanges({
@@ -215,42 +211,39 @@ describe("dev", () => {
     await waitUntilLocalFilesVersion(6n);
 
     await expectDirs().resolves.toMatchInlineSnapshot(`
-        {
-          "filesVersionDirs": {
-            "1": {
-              ".gadget/": "",
-            },
-            "2": {
-              ".gadget/": "",
-              "file.txt": "file v2",
-            },
-            "3": {
-              ".gadget/": "",
-              "file.txt": "file v3",
-            },
-            "4": {
-              ".gadget/": "",
-            },
-            "5": {
-              ".gadget/": "",
-              "directory/": "",
-            },
-            "6": {
-              ".gadget/": "",
-            },
-          },
-          "gadgetDir": {
+      {
+        "filesVersionDirs": {
+          "1": {
             ".gadget/": "",
           },
-          "localDir": {
+          "2": {
             ".gadget/": "",
-            ".gadget/backup/": "",
-            ".gadget/backup/directory/": "",
-            ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"6"}}}",
+            "file.txt": "file v2",
           },
-        }
-      `);
+          "3": {
+            ".gadget/": "",
+            "file.txt": "file v3",
+          },
+          "4": {
+            ".gadget/": "",
+          },
+          "5": {
+            ".gadget/": "",
+            "directory/": "",
+          },
+          "6": {
+            ".gadget/": "",
+          },
+        },
+        "gadgetDir": {
+          ".gadget/": "",
+        },
+        "localDir": {
+          ".gadget/": "",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"6"}}}",
+        },
+      }
+    `);
 
     // receive a bunch of files
     const files = Array.from({ length: 10 }, (_, i) => `file${i + 1}.txt`);
@@ -263,44 +256,30 @@ describe("dev", () => {
     await waitUntilLocalFilesVersion(7n);
 
     await expectDirs().resolves.toMatchInlineSnapshot(`
-        {
-          "filesVersionDirs": {
-            "1": {
-              ".gadget/": "",
-            },
-            "2": {
-              ".gadget/": "",
-              "file.txt": "file v2",
-            },
-            "3": {
-              ".gadget/": "",
-              "file.txt": "file v3",
-            },
-            "4": {
-              ".gadget/": "",
-            },
-            "5": {
-              ".gadget/": "",
-              "directory/": "",
-            },
-            "6": {
-              ".gadget/": "",
-            },
-            "7": {
-              ".gadget/": "",
-              "file1.txt": "file1.txt",
-              "file10.txt": "file10.txt",
-              "file2.txt": "file2.txt",
-              "file3.txt": "file3.txt",
-              "file4.txt": "file4.txt",
-              "file5.txt": "file5.txt",
-              "file6.txt": "file6.txt",
-              "file7.txt": "file7.txt",
-              "file8.txt": "file8.txt",
-              "file9.txt": "file9.txt",
-            },
+      {
+        "filesVersionDirs": {
+          "1": {
+            ".gadget/": "",
           },
-          "gadgetDir": {
+          "2": {
+            ".gadget/": "",
+            "file.txt": "file v2",
+          },
+          "3": {
+            ".gadget/": "",
+            "file.txt": "file v3",
+          },
+          "4": {
+            ".gadget/": "",
+          },
+          "5": {
+            ".gadget/": "",
+            "directory/": "",
+          },
+          "6": {
+            ".gadget/": "",
+          },
+          "7": {
             ".gadget/": "",
             "file1.txt": "file1.txt",
             "file10.txt": "file10.txt",
@@ -313,25 +292,36 @@ describe("dev", () => {
             "file8.txt": "file8.txt",
             "file9.txt": "file9.txt",
           },
-          "localDir": {
-            ".gadget/": "",
-            ".gadget/backup/": "",
-            ".gadget/backup/directory/": "",
-            ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}}}",
-            "file1.txt": "file1.txt",
-            "file10.txt": "file10.txt",
-            "file2.txt": "file2.txt",
-            "file3.txt": "file3.txt",
-            "file4.txt": "file4.txt",
-            "file5.txt": "file5.txt",
-            "file6.txt": "file6.txt",
-            "file7.txt": "file7.txt",
-            "file8.txt": "file8.txt",
-            "file9.txt": "file9.txt",
-          },
-        }
-      `);
+        },
+        "gadgetDir": {
+          ".gadget/": "",
+          "file1.txt": "file1.txt",
+          "file10.txt": "file10.txt",
+          "file2.txt": "file2.txt",
+          "file3.txt": "file3.txt",
+          "file4.txt": "file4.txt",
+          "file5.txt": "file5.txt",
+          "file6.txt": "file6.txt",
+          "file7.txt": "file7.txt",
+          "file8.txt": "file8.txt",
+          "file9.txt": "file9.txt",
+        },
+        "localDir": {
+          ".gadget/": "",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}}}",
+          "file1.txt": "file1.txt",
+          "file10.txt": "file10.txt",
+          "file2.txt": "file2.txt",
+          "file3.txt": "file3.txt",
+          "file4.txt": "file4.txt",
+          "file5.txt": "file5.txt",
+          "file6.txt": "file6.txt",
+          "file7.txt": "file7.txt",
+          "file8.txt": "file8.txt",
+          "file9.txt": "file9.txt",
+        },
+      }
+    `);
   });
 
   it("writes changes from gadget in the order they were received", async () => {
@@ -387,44 +377,30 @@ describe("dev", () => {
     await waitUntilLocalFilesVersion(7n);
 
     await expectDirs().resolves.toMatchInlineSnapshot(`
-        {
-          "filesVersionDirs": {
-            "1": {
-              ".gadget/": "",
-            },
-            "2": {
-              ".gadget/": "",
-              "file.txt": "file v2",
-            },
-            "3": {
-              ".gadget/": "",
-              "file.txt": "file v3",
-            },
-            "4": {
-              ".gadget/": "",
-            },
-            "5": {
-              ".gadget/": "",
-              "directory/": "",
-            },
-            "6": {
-              ".gadget/": "",
-            },
-            "7": {
-              ".gadget/": "",
-              "file1.txt": "file1.txt",
-              "file10.txt": "file10.txt",
-              "file2.txt": "file2.txt",
-              "file3.txt": "file3.txt",
-              "file4.txt": "file4.txt",
-              "file5.txt": "file5.txt",
-              "file6.txt": "file6.txt",
-              "file7.txt": "file7.txt",
-              "file8.txt": "file8.txt",
-              "file9.txt": "file9.txt",
-            },
+      {
+        "filesVersionDirs": {
+          "1": {
+            ".gadget/": "",
           },
-          "gadgetDir": {
+          "2": {
+            ".gadget/": "",
+            "file.txt": "file v2",
+          },
+          "3": {
+            ".gadget/": "",
+            "file.txt": "file v3",
+          },
+          "4": {
+            ".gadget/": "",
+          },
+          "5": {
+            ".gadget/": "",
+            "directory/": "",
+          },
+          "6": {
+            ".gadget/": "",
+          },
+          "7": {
             ".gadget/": "",
             "file1.txt": "file1.txt",
             "file10.txt": "file10.txt",
@@ -437,25 +413,36 @@ describe("dev", () => {
             "file8.txt": "file8.txt",
             "file9.txt": "file9.txt",
           },
-          "localDir": {
-            ".gadget/": "",
-            ".gadget/backup/": "",
-            ".gadget/backup/directory/": "",
-            ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}}}",
-            "file1.txt": "file1.txt",
-            "file10.txt": "file10.txt",
-            "file2.txt": "file2.txt",
-            "file3.txt": "file3.txt",
-            "file4.txt": "file4.txt",
-            "file5.txt": "file5.txt",
-            "file6.txt": "file6.txt",
-            "file7.txt": "file7.txt",
-            "file8.txt": "file8.txt",
-            "file9.txt": "file9.txt",
-          },
-        }
-      `);
+        },
+        "gadgetDir": {
+          ".gadget/": "",
+          "file1.txt": "file1.txt",
+          "file10.txt": "file10.txt",
+          "file2.txt": "file2.txt",
+          "file3.txt": "file3.txt",
+          "file4.txt": "file4.txt",
+          "file5.txt": "file5.txt",
+          "file6.txt": "file6.txt",
+          "file7.txt": "file7.txt",
+          "file8.txt": "file8.txt",
+          "file9.txt": "file9.txt",
+        },
+        "localDir": {
+          ".gadget/": "",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}}}",
+          "file1.txt": "file1.txt",
+          "file10.txt": "file10.txt",
+          "file2.txt": "file2.txt",
+          "file3.txt": "file3.txt",
+          "file4.txt": "file4.txt",
+          "file5.txt": "file5.txt",
+          "file6.txt": "file6.txt",
+          "file7.txt": "file7.txt",
+          "file8.txt": "file8.txt",
+          "file9.txt": "file9.txt",
+        },
+      }
+    `);
   });
 
   it("writes all received files before stopping", async () => {
@@ -512,49 +499,34 @@ describe("dev", () => {
     await testCtx.done;
 
     await expectDirs().resolves.toMatchInlineSnapshot(`
-        {
-          "filesVersionDirs": {
-            "1": {
-              ".gadget/": "",
-            },
-            "2": {
-              ".gadget/": "",
-              "file.js": "file v2",
-            },
-            "3": {
-              ".gadget/": "",
-              "file.js": "file v2",
-              "file.txt": "file v3",
-            },
-            "4": {
-              ".gadget/": "",
-              "file.js": "file v2",
-            },
-            "5": {
-              ".gadget/": "",
-              "directory/": "",
-              "file.js": "file v2",
-            },
-            "6": {
-              ".gadget/": "",
-              "file.js": "file v2",
-            },
-            "7": {
-              ".gadget/": "",
-              "file.js": "file v2",
-              "file1.txt": "file1.txt",
-              "file10.txt": "file10.txt",
-              "file2.txt": "file2.txt",
-              "file3.txt": "file3.txt",
-              "file4.txt": "file4.txt",
-              "file5.txt": "file5.txt",
-              "file6.txt": "file6.txt",
-              "file7.txt": "file7.txt",
-              "file8.txt": "file8.txt",
-              "file9.txt": "file9.txt",
-            },
+      {
+        "filesVersionDirs": {
+          "1": {
+            ".gadget/": "",
           },
-          "gadgetDir": {
+          "2": {
+            ".gadget/": "",
+            "file.js": "file v2",
+          },
+          "3": {
+            ".gadget/": "",
+            "file.js": "file v2",
+            "file.txt": "file v3",
+          },
+          "4": {
+            ".gadget/": "",
+            "file.js": "file v2",
+          },
+          "5": {
+            ".gadget/": "",
+            "directory/": "",
+            "file.js": "file v2",
+          },
+          "6": {
+            ".gadget/": "",
+            "file.js": "file v2",
+          },
+          "7": {
             ".gadget/": "",
             "file.js": "file v2",
             "file1.txt": "file1.txt",
@@ -568,26 +540,38 @@ describe("dev", () => {
             "file8.txt": "file8.txt",
             "file9.txt": "file9.txt",
           },
-          "localDir": {
-            ".gadget/": "",
-            ".gadget/backup/": "",
-            ".gadget/backup/directory/": "",
-            ".gadget/backup/file.txt": "file v3",
-            ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}}}",
-            "file.js": "file v2",
-            "file1.txt": "file1.txt",
-            "file10.txt": "file10.txt",
-            "file2.txt": "file2.txt",
-            "file3.txt": "file3.txt",
-            "file4.txt": "file4.txt",
-            "file5.txt": "file5.txt",
-            "file6.txt": "file6.txt",
-            "file7.txt": "file7.txt",
-            "file8.txt": "file8.txt",
-            "file9.txt": "file9.txt",
-          },
-        }
-      `);
+        },
+        "gadgetDir": {
+          ".gadget/": "",
+          "file.js": "file v2",
+          "file1.txt": "file1.txt",
+          "file10.txt": "file10.txt",
+          "file2.txt": "file2.txt",
+          "file3.txt": "file3.txt",
+          "file4.txt": "file4.txt",
+          "file5.txt": "file5.txt",
+          "file6.txt": "file6.txt",
+          "file7.txt": "file7.txt",
+          "file8.txt": "file8.txt",
+          "file9.txt": "file9.txt",
+        },
+        "localDir": {
+          ".gadget/": "",
+          ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"7"}}}",
+          "file.js": "file v2",
+          "file1.txt": "file1.txt",
+          "file10.txt": "file10.txt",
+          "file2.txt": "file2.txt",
+          "file3.txt": "file3.txt",
+          "file4.txt": "file4.txt",
+          "file5.txt": "file5.txt",
+          "file6.txt": "file6.txt",
+          "file7.txt": "file7.txt",
+          "file8.txt": "file8.txt",
+          "file9.txt": "file9.txt",
+        },
+      }
+    `);
   });
 
   it("doesn't write changes from gadget to the local filesystem if the file is ignored", async () => {

--- a/spec/commands/pull.spec.ts
+++ b/spec/commands/pull.spec.ts
@@ -151,8 +151,6 @@ describe("pull", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/backup/": "",
-          ".gadget/backup/local-file.js": "// local",
           ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
           "gadget-file.js": "// gadget",
         },
@@ -194,8 +192,6 @@ describe("pull", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/backup/": "",
-          ".gadget/backup/local-file.js": "// local",
           ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
           "gadget-file.js": "// gadget",
         },
@@ -316,9 +312,6 @@ describe("pull", () => {
         },
         "localDir": {
           ".gadget/": "",
-          ".gadget/backup/": "",
-          ".gadget/backup/.gadget/": "",
-          ".gadget/backup/.gadget/local.js": "// .gadget/local",
           ".gadget/sync.json": "{"application":"test","environment":"development","environments":{"development":{"filesVersion":"2"}}}",
           "gadget-file.js": "// gadget",
         },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Eliminates the `.gadget/backup/` mechanism; delete events now remove files directly and tests/snapshots updated accordingly.
> 
> - **Filesync behavior**:
>   - Remove use of `.gadget/backup/`; `writeToLocalFilesystem` now calls `fs.remove` to delete files and records deletes directly.
>   - Drop backup-move logic, retries, and related error handling; remove imports for `ms`, `p-retry`, `isEEXISTError`, `isENOTDIRError`.
> - **Tests**:
>   - Update specs and inline snapshots in `spec/commands/dev.spec.ts`, `spec/commands/pull.spec.ts`, and `spec/services/filesync/filesync.spec.ts` to remove `.gadget/backup/` expectations.
>   - Delete backup-specific tests that validated moving files to backup and handling collisions.
> - **Release note**:
>   - Add changeset: major change removing `.gadget/backup/` and documenting permanent delete behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55b33a38e6ebc7767aa79d68f072e38a37cddd57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->