### PR TITLE
Remove support for old sync.json files

### DIFF
--- a/.changeset/remove-sync-json-v04.md
+++ b/.changeset/remove-sync-json-v04.md
@@ -1,0 +1,5 @@
+---
+ggt: major
+---
+
+Remove support for `.gadget/sync.json` files produced by ggt v0.4.x.

--- a/spec/services/filesync/sync-json.spec.ts
+++ b/spec/services/filesync/sync-json.spec.ts
@@ -86,24 +86,6 @@ describe("SyncJson.loadOrInit", () => {
     `);
   });
 
-  it("loads state from .gadget/sync.json (v0.4)", async () => {
-    await outputSyncJson({
-      app: testApp.slug,
-      filesVersion: "77",
-      mtime: 1658153625236,
-    });
-
-    const syncJson = await SyncJson.loadOrInit(testCtx, { command, args, directory: localDir });
-
-    expect(syncJson.state).toEqual({
-      application: testApp.slug,
-      environment: "development",
-      environments: {
-        development: { filesVersion: "77" },
-      },
-    });
-  });
-
   it("uses default state if .gadget/sync.json does not exist and the directory is empty", async () => {
     const syncJson = await SyncJson.loadOrInit(testCtx, { command, args, directory: localDir });
 

--- a/src/services/filesync/sync-json.ts
+++ b/src/services/filesync/sync-json.ts
@@ -542,29 +542,10 @@ export const SyncJsonStateV1 = z.object({
   environments: z.record(z.object({ filesVersion: z.string() })),
 });
 
-export const SyncJsonStateV04 = z.object({
-  app: z.string(),
-  filesVersion: z.string(),
-  mtime: z.number(),
-});
+export const AnySyncJsonState = SyncJsonStateV1;
 
-export const AnySyncJsonState = z.union([SyncJsonStateV1, SyncJsonStateV04]);
-
-export const SyncJsonState = AnySyncJsonState.transform((state): SyncJsonStateV1 => {
-  if ("environment" in state) {
-    // it's a v1 state
-    return state;
-  }
-
-  // it's a v0.4 state, transform it to a v1 state
-  return {
-    application: state.app,
-    environment: "development",
-    environments: { development: { filesVersion: state.filesVersion } },
-  };
-});
+export const SyncJsonState = SyncJsonStateV1;
 
 export type SyncJsonStateV1 = z.infer<typeof SyncJsonStateV1>;
-export type SyncJsonStateV04 = z.infer<typeof SyncJsonStateV04>;
 export type AnySyncJsonState = z.infer<typeof AnySyncJsonState>;
 export type SyncJsonState = z.infer<typeof SyncJsonState>;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Drops support for v0.4 `.gadget/sync.json` files and makes sync state parsing V1-only; removes corresponding legacy test and adds a major changeset.
> 
> - **Filesync**:
>   - Remove legacy v0.4 schema handling: delete `SyncJsonStateV04`, the union with V1, and the V0.4→V1 transform; `AnySyncJsonState` and `SyncJsonState` are now V1-only.
> - **Tests**:
>   - Remove test for loading v0.4 `.gadget/sync.json`.
> - **Changeset**:
>   - Add major release note for removing v0.4 support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f82f5033d36159e673cea28203741829ebf74424. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->