### PR TITLE
Add retry logic for SSL/TLS errors in FileSync

### DIFF
--- a/.changeset/retry-ssl-errors.md
+++ b/.changeset/retry-ssl-errors.md
@@ -1,0 +1,7 @@
+---
+"ggt": patch
+---
+
+Retry HTTP requests on SSL/TLS errors.
+
+All HTTP requests will now automatically retry when encountering transient SSL/TLS errors like `ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC` or `EPROTO`. This improves resilience against transient network issues that can occur during SSL/TLS handshakes.

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -12,6 +12,7 @@ enoent
 enotdir
 enotempty
 envrc
+eproto
 esbuild
 execa
 filesync
@@ -28,7 +29,7 @@ jsonifiable
 jsonify
 linkcode
 localappdata
-Logql
+logql
 nothrow
 notificationcenter
 notifysend
@@ -42,6 +43,7 @@ pageup
 postbuild
 printlns
 promisable
+retryable
 revparse
 sindre
 sorhus

--- a/src/services/filesync/filesync.ts
+++ b/src/services/filesync/filesync.ts
@@ -20,6 +20,7 @@ import {
 } from "../app/edit/operation.js";
 import type { Command } from "../command/command.js";
 import type { Context } from "../command/context.js";
+import { DEFAULT_RETRYABLE_HTTP_ERROR_CODES } from "../http/http.js";
 import { confirm } from "../output/confirm.js";
 import type { Fields } from "../output/log/field.js";
 import { Level } from "../output/log/level.js";
@@ -931,6 +932,11 @@ export class FileSync {
             // we can retry this request because
             // expectedRemoteFilesVersion makes it idempotent
             methods: ["POST"],
+            errorCodes: [
+              ...DEFAULT_RETRYABLE_HTTP_ERROR_CODES,
+              "ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC",
+              "EPROTO", // General SSL/TLS protocol errors
+            ],
             calculateDelay: ({ error, computedValue }) => {
               if (isFilesVersionMismatchError(error.response?.body)) {
                 // don't retry if we get a files version mismatch error


### PR DESCRIPTION
Fixes #1913

- Implemented retry mechanism for specific SSL/TLS errors, including "ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC" and "EPROTO".
- Updated tests to verify retry behavior on SSL/TLS errors and ensure proper handling of "Files version mismatch" errors.
- Enhanced error handling in the HTTP service to accommodate new error codes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens network resilience by expanding HTTP retry behavior and validating it in FileSync flows.
> 
> - Adds `DEFAULT_RETRYABLE_HTTP_*` constants in `http.ts` and includes SSL/TLS errors (e.g., `ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC`, `EPROTO`); wires defaults into `got` retry config
> - Updates `FileSync` mutation retry config to include the new SSL/TLS error codes while still skipping retries on `Files version mismatch`
> - New spec verifies retry on SSL/TLS errors and preserves existing behavior for mismatch errors
> - Updates dictionary and adds a changeset note
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2fd9cc3445bfe4a261003ec78ce2e1514823954. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->