### PR TITLE
Add ggt shopify connect command

### DIFF
--- a/.changeset/shopify-connect-command.md
+++ b/.changeset/shopify-connect-command.md
@@ -1,0 +1,10 @@
+---
+"ggt": minor
+---
+
+Add `ggt shopify connect` to configure a Gadget app's Shopify connection.
+
+This command imports your local Shopify CLI session, creates the Shopify
+connection files, and syncs them into your project.
+
+`ggt shopify connect` only works for apps on framework version 1.7 or newer.

--- a/spec/commands/__snapshots__/completion.spec.ts.snap
+++ b/spec/commands/__snapshots__/completion.spec.ts.snap
@@ -16,12 +16,12 @@ _ggt_completions() {
     --from-file)
       COMPREPLY=($(compgen -f -- "$cur"))
       return ;;
-    --file-push-delay|--file-watch-debounce|--file-watch-poll-interval|--file-watch-poll-timeout|--file-watch-rename-timeout|--allow|--model|--start|--port|-p)
+    --file-push-delay|--file-watch-debounce|--file-watch-poll-interval|--file-watch-poll-timeout|--file-watch-rename-timeout|--allow|--model|--app-name|--shopify-organization-id|--start|--port|-p)
       return ;;
   esac
 
   if [[ $COMP_CWORD -eq 1 ]]; then
-    COMPREPLY=($(compgen -W "dev deploy status problems problem push pull var env envs add model action field open list login logout logs log debugger whoami configure agent-plugin eval version completion --help -h --version --verbose -v --telemetry --json" -- "$cur"))
+    COMPREPLY=($(compgen -W "dev deploy status problems problem push pull var env envs add model action field shopify open list login logout logs log debugger whoami configure agent-plugin eval version completion --help -h --version --verbose -v --telemetry --json" -- "$cur"))
     return
   fi
 
@@ -265,6 +265,37 @@ _ggt_completions() {
         case "$sub_cmd" in
           add)
             COMPREPLY=($(compgen -W "--application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --help -h --version --verbose -v --telemetry --json" -- "$cur"))
+            ;;
+          *)
+            COMPREPLY=($(compgen -W "--application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --help -h --version --verbose -v --telemetry --json" -- "$cur"))
+            ;;
+        esac
+      fi
+      ;;
+    shopify)
+      local sub_cmd=
+      local __skip_next=0
+      for ((i=2; i < COMP_CWORD; i++)); do
+        local w="\${COMP_WORDS[i]}"
+        if [[ $__skip_next -eq 1 ]]; then
+          __skip_next=0
+          continue
+        fi
+        case "$w" in
+          --application|-a|--app|--environment|-e|--env|--allow) __skip_next=1; continue ;;
+        esac
+        if [[ "$w" != -* ]]; then
+          sub_cmd="$w"
+          break
+        fi
+      done
+
+      if [[ -z "$sub_cmd" ]]; then
+        COMPREPLY=($(compgen -W "connect --application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --help -h --version --verbose -v --telemetry --json" -- "$cur"))
+      else
+        case "$sub_cmd" in
+          connect)
+            COMPREPLY=($(compgen -W "--application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --app-name --shopify-organization-id --help -h --version --verbose -v --telemetry --json" -- "$cur"))
             ;;
           *)
             COMPREPLY=($(compgen -W "--application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --help -h --version --verbose -v --telemetry --json" -- "$cur"))
@@ -532,6 +563,7 @@ complete -c ggt -n '__fish_use_subcommand' -a 'add' -d 'Add resources to your ap
 complete -c ggt -n '__fish_use_subcommand' -a 'model' -d 'Add and manage models in your app'
 complete -c ggt -n '__fish_use_subcommand' -a 'action' -d 'Add and manage actions'
 complete -c ggt -n '__fish_use_subcommand' -a 'field' -d 'Manage fields on your models'
+complete -c ggt -n '__fish_use_subcommand' -a 'shopify' -d 'Manage Shopify connection'
 complete -c ggt -n '__fish_use_subcommand' -a 'open' -d 'Open your app in a browser'
 complete -c ggt -n '__fish_use_subcommand' -a 'list' -d 'List your Gadget apps'
 complete -c ggt -n '__fish_use_subcommand' -a 'login' -d 'Log in to Gadget'
@@ -864,6 +896,29 @@ complete -c ggt -n '__fish_seen_subcommand_from field' -l telemetry -d 'Enable t
 complete -c ggt -n '__ggt_seen_subcommand field -- add -- --application -a --app --environment -e --env --allow' -l telemetry -d 'Enable telemetry'
 complete -c ggt -n '__fish_seen_subcommand_from field' -l json -d 'Output as JSON where supported'
 complete -c ggt -n '__ggt_seen_subcommand field -- add -- --application -a --app --environment -e --env --allow' -l json -d 'Output as JSON where supported'
+
+# shopify
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l application -s a -rfa '(__ggt_complete)' -d 'Gadget app to use'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l app -rfa '(__ggt_complete)' -d 'Gadget app to use'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l environment -s e -rfa '(__ggt_complete)' -d 'Environment to use'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l env -rfa '(__ggt_complete)' -d 'Environment to use'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l allow-different-app -d 'Allow syncing with a different app'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l allow-unknown-directory -d 'Allow syncing to an existing directory'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l allow -x -d 'Enable allow flags (comma-separated)'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l allow-all -d 'Enable all --allow-* flags'
+complete -c ggt -n '__ggt_needs_subcommand shopify -- --application -a --app --environment -e --env --allow' -a 'connect' -d 'Configure the Shopify connection for your application'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l app-name -x -d 'Shopify app name override'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l shopify-organization-id -x -d 'Shopify organization ID to use when your account has multiple organizations'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l help -s h -d 'Show command help'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l help -s h -d 'Show command help'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l version -d 'Print the ggt version'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l version -d 'Print the ggt version'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l verbose -s v -d 'Increase output verbosity (-vv for debug, -vvv for trace)'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l verbose -s v -d 'Increase output verbosity (-vv for debug, -vvv for trace)'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l telemetry -d 'Enable telemetry'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l telemetry -d 'Enable telemetry'
+complete -c ggt -n '__fish_seen_subcommand_from shopify' -l json -d 'Output as JSON where supported'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l json -d 'Output as JSON where supported'
 
 # open
 complete -c ggt -n '__fish_seen_subcommand_from open' -l application -s a -rfa '(__ggt_complete)' -d 'Gadget app to use'
@@ -1636,6 +1691,67 @@ _ggt_field() {
   esac
 }
 
+_ggt_shopify() {
+  local -a subcommands
+  local state
+
+  _arguments -C \\
+    '(--help -h)''--help[Show command help]' \\
+            '(--help -h)''-h[Show command help]' \\
+    '--version[Print the ggt version]' \\
+    '(--verbose -v)''--verbose[Increase output verbosity (-vv for debug, -vvv for trace)]' \\
+            '(--verbose -v)''-v[Increase output verbosity (-vv for debug, -vvv for trace)]' \\
+    '--telemetry[Enable telemetry]' \\
+    '--json[Output as JSON where supported]' \\
+    '(--application -a --app)''--application[Gadget app to use]:value:_ggt_dynamic' \\
+            '(--application -a --app)''-a[Gadget app to use]:value:_ggt_dynamic' \\
+            '(--application -a --app)''--app[Gadget app to use]:value:_ggt_dynamic' \\
+    '(--environment -e --env)''--environment[Environment to use]:value:_ggt_dynamic' \\
+            '(--environment -e --env)''-e[Environment to use]:value:_ggt_dynamic' \\
+            '(--environment -e --env)''--env[Environment to use]:value:_ggt_dynamic' \\
+    '--allow-different-app[Allow syncing with a different app]' \\
+    '--allow-unknown-directory[Allow syncing to an existing directory]' \\
+    '--allow[Enable allow flags (comma-separated)]:value: ' \\
+    '--allow-all[Enable all --allow-* flags]' \\
+    '1:subcommand:->subcommand' \\
+    '*::arg:->args'
+
+  case $state in
+    subcommand)
+      subcommands=(
+        'connect:Configure the Shopify connection for your application'
+      )
+      _describe -t subcommands 'shopify subcommand' subcommands
+      ;;
+    args)
+      case $words[1] in
+        connect)
+          _arguments \\
+            '(--help -h)''--help[Show command help]' \\
+            '(--help -h)''-h[Show command help]' \\
+            '--version[Print the ggt version]' \\
+            '(--verbose -v)''--verbose[Increase output verbosity (-vv for debug, -vvv for trace)]' \\
+            '(--verbose -v)''-v[Increase output verbosity (-vv for debug, -vvv for trace)]' \\
+            '--telemetry[Enable telemetry]' \\
+            '--json[Output as JSON where supported]' \\
+            '(--application -a --app)''--application[Gadget app to use]:value:_ggt_dynamic' \\
+            '(--application -a --app)''-a[Gadget app to use]:value:_ggt_dynamic' \\
+            '(--application -a --app)''--app[Gadget app to use]:value:_ggt_dynamic' \\
+            '(--environment -e --env)''--environment[Environment to use]:value:_ggt_dynamic' \\
+            '(--environment -e --env)''-e[Environment to use]:value:_ggt_dynamic' \\
+            '(--environment -e --env)''--env[Environment to use]:value:_ggt_dynamic' \\
+            '--allow-different-app[Allow syncing with a different app]' \\
+            '--allow-unknown-directory[Allow syncing to an existing directory]' \\
+            '--allow[Enable allow flags (comma-separated)]:value: ' \\
+            '--allow-all[Enable all --allow-* flags]' \\
+            '--app-name[Shopify app name override]:value: ' \\
+            '--shopify-organization-id[Shopify organization ID to use when your account has multiple organizations]:value: '
+          ;;
+      esac
+      ;;
+  esac
+}
+
 _ggt_configure() {
   local -a subcommands
   local state
@@ -1844,6 +1960,7 @@ _ggt() {
         'model:Add and manage models in your app'
         'action:Add and manage actions'
         'field:Manage fields on your models'
+        'shopify:Manage Shopify connection'
         'open:Open your app in a browser'
         'list:List your Gadget apps'
         'login:Log in to Gadget'
@@ -2019,6 +2136,9 @@ _ggt() {
           ;;
         field)
           _ggt_field
+          ;;
+        shopify)
+          _ggt_shopify
           ;;
         open)
           _arguments \\

--- a/spec/commands/__snapshots__/root.spec.ts.snap
+++ b/spec/commands/__snapshots__/root.spec.ts.snap
@@ -2692,6 +2692,161 @@ Run ggt push --help for more information.
 "
 `;
 
+exports[`root > when shopify is given > prints the usage for connect when --help is passed 1`] = `
+"Configure the Shopify connection for your application
+
+Creates development and production Shopify app configs, adds the
+default Shopify models, and adds the required default Shopify scopes.
+
+USAGE
+  ggt shopify connect [flags]
+
+FLAGS
+  -a, --app, --application <app>
+        Gadget app to use. The app slug is the subdomain portion of your app URL
+        (e.g., my-app from my-app.gadget.app). Can be omitted when
+        .gadget/sync.json already records the app.
+
+  -e, --env, --environment <env>
+        Environment to use. Defaults to the development environment. Production
+        is read-only for most commands.
+
+      --app-name <value>
+        Shopify app name override. Defaults to your Gadget app slug.
+
+      --shopify-organization-id <value>
+        Shopify organization ID to use when your account has multiple
+        organizations
+
+ADDITIONAL FLAGS
+      --allow <flag,...>
+        Enable allow flags (comma-separated)
+
+      --allow-all
+        Enable all --allow-* flags
+
+      --allow-different-app
+        Allow syncing with a different app. Overrides the app recorded in
+        .gadget/sync.json with the one specified by --app. Use this when you
+        want to reuse an existing directory for a different app.
+
+      --allow-unknown-directory
+        Allow syncing to an existing directory. Normally, a directory must be
+        empty or already contain .gadget/sync.json. Use this when you want to
+        initialize sync in a directory with existing content.
+
+EXAMPLES
+  $ ggt shopify connect
+  $ ggt shopify connect --app-name my-shop
+  $ ggt shopify connect --shopify-organization-id 123456789
+"
+`;
+
+exports[`root > when shopify is given > prints the usage for connect when -h is passed 1`] = `
+"Configure the Shopify connection for your application
+
+USAGE
+  ggt shopify connect [flags]
+
+FLAGS
+  -a, --app, --application <app>         Gadget app to use
+  -e, --env, --environment <env>         Environment to use
+      --app-name <value>                 Shopify app name override
+      --shopify-organization-id <value>  Shopify organization ID to use when your account has multiple organizations
+
+EXAMPLES
+  $ ggt shopify connect
+  $ ggt shopify connect --app-name my-shop
+  $ ggt shopify connect --shopify-organization-id 123456789
+
+Run ggt shopify connect --help for more information.
+"
+`;
+
+exports[`root > when shopify is given > prints the usage when --help is passed 1`] = `
+"Manage Shopify connection
+
+USAGE
+  ggt shopify <command> [flags]
+
+COMMANDS
+  connect    Configure the Shopify connection for your application
+
+FLAGS
+  -a, --app, --application <app>
+        Gadget app to use. The app slug is the subdomain portion of your app URL
+        (e.g., my-app from my-app.gadget.app). Can be omitted when
+        .gadget/sync.json already records the app.
+
+  -e, --env, --environment <env>
+        Environment to use. Defaults to the development environment. Production
+        is read-only for most commands.
+
+ADDITIONAL FLAGS
+      --allow <flag,...>
+        Enable allow flags (comma-separated)
+
+      --allow-all
+        Enable all --allow-* flags
+
+      --allow-different-app
+        Allow syncing with a different app. Overrides the app recorded in
+        .gadget/sync.json with the one specified by --app. Use this when you
+        want to reuse an existing directory for a different app.
+
+      --allow-unknown-directory
+        Allow syncing to an existing directory. Normally, a directory must be
+        empty or already contain .gadget/sync.json. Use this when you want to
+        initialize sync in a directory with existing content.
+
+EXAMPLES
+  $ ggt shopify connect
+  $ ggt shopify connect --app-name my-shop
+"
+`;
+
+exports[`root > when shopify is given > prints the usage when -h is passed 1`] = `
+"Manage Shopify connection
+
+USAGE
+  ggt shopify <command> [flags]
+
+COMMANDS
+  connect    Configure the Shopify connection for your application
+
+FLAGS
+  -a, --app, --application <app>  Gadget app to use
+  -e, --env, --environment <env>  Environment to use
+
+EXAMPLES
+  $ ggt shopify connect
+  $ ggt shopify connect --app-name my-shop
+
+Run ggt shopify --help for more information.
+"
+`;
+
+exports[`root > when shopify is given > shows help when invoked without a subcommand 1`] = `
+"Manage Shopify connection
+
+USAGE
+  ggt shopify <command> [flags]
+
+COMMANDS
+  connect    Configure the Shopify connection for your application
+
+FLAGS
+  -a, --app, --application <app>  Gadget app to use
+  -e, --env, --environment <env>  Environment to use
+
+EXAMPLES
+  $ ggt shopify connect
+  $ ggt shopify connect --app-name my-shop
+
+Run ggt shopify --help for more information.
+"
+`;
+
 exports[`root > when status is given > prints the usage when --help is passed 1`] = `
 "Show sync state and pending file changes
 

--- a/spec/commands/root.spec.ts
+++ b/spec/commands/root.spec.ts
@@ -90,6 +90,7 @@ describe("root", () => {
         model           Add and manage models in your app
         action          Add and manage actions
         field           Manage fields on your models
+        shopify         Manage Shopify connection
         var             Manage your app's environment variables
         env             Manage your app's environments
         open            Open your app in a browser
@@ -149,6 +150,7 @@ describe("root", () => {
         model           Add and manage models in your app
         action          Add and manage actions
         field           Manage fields on your models
+        shopify         Manage Shopify connection
         var             Manage your app's environment variables
         env             Manage your app's environments
         open            Open your app in a browser

--- a/spec/commands/shopify.spec.ts
+++ b/spec/commands/shopify.spec.ts
@@ -1,0 +1,211 @@
+import path from "node:path";
+
+import fs from "fs-extra";
+import type { JsonObject } from "type-fest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import shopify from "../../src/commands/shopify.ts";
+import {
+  CONNECT_SHOPIFY_MUTATION,
+  IMPORT_SHOPIFY_CLI_SESSION_MUTATION,
+  SHOPIFY_ORGANIZATIONS_QUERY,
+} from "../../src/services/app/edit/operation.ts";
+import { runCommand } from "../../src/services/command/run.ts";
+import { config } from "../../src/services/config/config.ts";
+import { nockTestApps } from "../__support__/app.ts";
+import { testCtx } from "../__support__/context.ts";
+import { expectError } from "../__support__/error.ts";
+import { makeSyncScenario } from "../__support__/filesync.ts";
+import { nockEditResponse } from "../__support__/graphql.ts";
+import { expectStdout } from "../__support__/output.ts";
+import { testDirPath } from "../__support__/paths.ts";
+import { loginTestUser } from "../__support__/user.ts";
+
+const sampleShopifyCliSessionPayload = (): JsonObject => ({
+  "accounts.shopify.com": {
+    "imported-user-id": {
+      identity: {
+        accessToken: "imported-access-token",
+        refreshToken: "imported-refresh-token",
+        expiresAt: "2030-01-01T00:00:00.000Z",
+        scopes: ["openid", "email"],
+        userId: "imported-user-id",
+        alias: "test@example.com",
+      },
+      applications: {
+        partners: {
+          accessToken: "imported-partners-token",
+          expiresAt: "2030-01-01T00:00:00.000Z",
+          scopes: ["https://api.shopify.com/auth/partners.app.cli.access"],
+        },
+      },
+    },
+  },
+});
+
+type ShopifyCliConfigLocation = "windows" | "macos" | "rest";
+
+const runtimeShopifyCliConfigLocation = (): ShopifyCliConfigLocation => {
+  if (config.windows) {
+    return "windows";
+  }
+
+  if (process.env["XDG_CONFIG_HOME"]) {
+    return "rest";
+  }
+
+  if (config.macos) {
+    return "macos";
+  }
+
+  return "rest";
+};
+
+const writeShopifyCliConfig = async (sessionPayload: JsonObject, location: ShopifyCliConfigLocation) => {
+  let configPath: string;
+
+  switch (location) {
+    case "windows":
+      configPath = path.join(testDirPath("windows-appdata"), "shopify-cli-kit-nodejs", "Config", "config.json");
+      break;
+    case "macos":
+      configPath = path.join(testDirPath("home-macos"), "Library", "Preferences", "shopify-cli-kit-nodejs", "config.json");
+      break;
+    case "rest":
+      configPath = path.join(testDirPath("xdg-config"), "shopify-cli-kit-nodejs", "config.json");
+      break;
+  }
+
+  await fs.outputFile(configPath, JSON.stringify({ sessionStore: JSON.stringify(sessionPayload) }));
+};
+
+const mockImportSuccess = (sessionPayload: JsonObject) =>
+  nockEditResponse({
+    operation: IMPORT_SHOPIFY_CLI_SESSION_MUTATION,
+    response: { data: { importShopifyCliSession: { success: true } } },
+    expectVariables: { configSessionPayload: sessionPayload },
+  });
+
+const mockSingleOrg = () =>
+  nockEditResponse({
+    operation: SHOPIFY_ORGANIZATIONS_QUERY,
+    response: {
+      data: {
+        shopifyOrganizations: [{ id: "org-1", name: "Org One", platform: "DEV" }],
+      },
+    },
+  });
+
+const mockConnectSuccess = (appName: string, shopifyOrganizationId: string) =>
+  nockEditResponse({
+    operation: CONNECT_SHOPIFY_MUTATION,
+    response: {
+      data: {
+        connectShopify: {
+          remoteFilesVersion: "2",
+          changed: [],
+          deleted: [],
+        },
+      },
+    },
+    expectVariables: { appName, shopifyOrganizationId },
+  });
+
+describe("shopify", () => {
+  beforeEach(async () => {
+    loginTestUser();
+    nockTestApps();
+    await makeSyncScenario();
+    vi.stubEnv("XDG_CONFIG_HOME", testDirPath("xdg-config"));
+    vi.stubEnv("APPDATA", testDirPath("windows-appdata"));
+  });
+
+  it("imports Shopify CLI session first and connects using the synced app slug by default", async () => {
+    const sessionPayload = sampleShopifyCliSessionPayload();
+    await writeShopifyCliConfig(sessionPayload, runtimeShopifyCliConfigLocation());
+
+    mockImportSuccess(sessionPayload);
+    mockSingleOrg();
+    mockConnectSuccess("test", "org-1");
+
+    await runCommand(testCtx, shopify, "connect");
+
+    expectStdout().toContain("Shopify connection configured successfully");
+  });
+
+  it("connects using an overridden app name and organization id", async () => {
+    const sessionPayload = sampleShopifyCliSessionPayload();
+    await writeShopifyCliConfig(sessionPayload, runtimeShopifyCliConfigLocation());
+
+    mockImportSuccess(sessionPayload);
+    mockConnectSuccess("custom-shopify-app", "org-2");
+
+    await runCommand(testCtx, shopify, "connect", "--app-name", "custom-shopify-app", "--shopify-organization-id", "org-2");
+
+    expectStdout().toContain("Shopify connection configured successfully");
+  });
+
+  it("errors with auth login guidance when Shopify CLI config is missing", async () => {
+    const error = await expectError(() => runCommand(testCtx, shopify, "connect"));
+    expect(error.message).toContain("shopify auth login");
+  });
+
+  it("errors when importing Shopify CLI session fails", async () => {
+    const sessionPayload = sampleShopifyCliSessionPayload();
+    await writeShopifyCliConfig(sessionPayload, runtimeShopifyCliConfigLocation());
+
+    nockEditResponse({
+      operation: IMPORT_SHOPIFY_CLI_SESSION_MUTATION,
+      response: { data: { importShopifyCliSession: { success: false } } },
+      expectVariables: { configSessionPayload: sessionPayload },
+    });
+
+    const error = await expectError(() => runCommand(testCtx, shopify, "connect"));
+    expect(error.message).toContain("Failed to import Shopify CLI session");
+  });
+
+  it("errors when no Shopify organizations are found", async () => {
+    const sessionPayload = sampleShopifyCliSessionPayload();
+    await writeShopifyCliConfig(sessionPayload, runtimeShopifyCliConfigLocation());
+
+    mockImportSuccess(sessionPayload);
+
+    nockEditResponse({
+      operation: SHOPIFY_ORGANIZATIONS_QUERY,
+      response: {
+        data: {
+          shopifyOrganizations: [],
+        },
+      },
+    });
+
+    const error = await expectError(() => runCommand(testCtx, shopify, "connect"));
+    expect(error.message).toContain("No Shopify organizations were found");
+  });
+
+  it("prints available organizations and errors when multiple organizations are found without an id", async () => {
+    const sessionPayload = sampleShopifyCliSessionPayload();
+    await writeShopifyCliConfig(sessionPayload, runtimeShopifyCliConfigLocation());
+
+    mockImportSuccess(sessionPayload);
+
+    nockEditResponse({
+      operation: SHOPIFY_ORGANIZATIONS_QUERY,
+      response: {
+        data: {
+          shopifyOrganizations: [
+            { id: "org-1", name: "Org One", platform: "DEV" },
+            { id: "org-2", name: "Org Two", platform: "DEV" },
+          ],
+        },
+      },
+    });
+
+    const error = await expectError(() => runCommand(testCtx, shopify, "connect"));
+
+    expect(error.message).toContain("--shopify-organization-id");
+    expectStdout().toContain("Shopify organizations available:");
+    expectStdout().toContain("org-1");
+    expectStdout().toContain("org-2");
+  });
+});

--- a/spec/commands/shopify.spec.ts
+++ b/spec/commands/shopify.spec.ts
@@ -43,37 +43,13 @@ const sampleShopifyCliSessionPayload = (): JsonObject => ({
   },
 });
 
-type ShopifyCliConfigLocation = "windows" | "macos" | "rest";
+const writeShopifyCliConfig = async (sessionPayload: JsonObject) => {
+  let configPath = path.join(testDirPath("xdg-config"), "shopify-cli-kit-nodejs", "config.json");
 
-const runtimeShopifyCliConfigLocation = (): ShopifyCliConfigLocation => {
   if (config.windows) {
-    return "windows";
-  }
-
-  if (process.env["XDG_CONFIG_HOME"]) {
-    return "rest";
-  }
-
-  if (config.macos) {
-    return "macos";
-  }
-
-  return "rest";
-};
-
-const writeShopifyCliConfig = async (sessionPayload: JsonObject, location: ShopifyCliConfigLocation) => {
-  let configPath: string;
-
-  switch (location) {
-    case "windows":
-      configPath = path.join(testDirPath("windows-appdata"), "shopify-cli-kit-nodejs", "Config", "config.json");
-      break;
-    case "macos":
-      configPath = path.join(testDirPath("home-macos"), "Library", "Preferences", "shopify-cli-kit-nodejs", "config.json");
-      break;
-    case "rest":
-      configPath = path.join(testDirPath("xdg-config"), "shopify-cli-kit-nodejs", "config.json");
-      break;
+    configPath = path.join(testDirPath("windows-appdata"), "shopify-cli-kit-nodejs", "Config", "config.json");
+  } else if (!process.env["XDG_CONFIG_HOME"] && config.macos) {
+    configPath = path.join(testDirPath("home-macos"), "Library", "Preferences", "shopify-cli-kit-nodejs", "config.json");
   }
 
   await fs.outputFile(configPath, JSON.stringify({ sessionStore: JSON.stringify(sessionPayload) }));
@@ -122,7 +98,7 @@ describe("shopify", () => {
 
   it("imports Shopify CLI session first and connects using the synced app slug by default", async () => {
     const sessionPayload = sampleShopifyCliSessionPayload();
-    await writeShopifyCliConfig(sessionPayload, runtimeShopifyCliConfigLocation());
+    await writeShopifyCliConfig(sessionPayload);
 
     mockImportSuccess(sessionPayload);
     mockSingleOrg();
@@ -135,7 +111,7 @@ describe("shopify", () => {
 
   it("connects using an overridden app name and organization id", async () => {
     const sessionPayload = sampleShopifyCliSessionPayload();
-    await writeShopifyCliConfig(sessionPayload, runtimeShopifyCliConfigLocation());
+    await writeShopifyCliConfig(sessionPayload);
 
     mockImportSuccess(sessionPayload);
     mockConnectSuccess("custom-shopify-app", "org-2");
@@ -152,7 +128,7 @@ describe("shopify", () => {
 
   it("errors when importing Shopify CLI session fails", async () => {
     const sessionPayload = sampleShopifyCliSessionPayload();
-    await writeShopifyCliConfig(sessionPayload, runtimeShopifyCliConfigLocation());
+    await writeShopifyCliConfig(sessionPayload);
 
     nockEditResponse({
       operation: IMPORT_SHOPIFY_CLI_SESSION_MUTATION,
@@ -166,7 +142,7 @@ describe("shopify", () => {
 
   it("errors when no Shopify organizations are found", async () => {
     const sessionPayload = sampleShopifyCliSessionPayload();
-    await writeShopifyCliConfig(sessionPayload, runtimeShopifyCliConfigLocation());
+    await writeShopifyCliConfig(sessionPayload);
 
     mockImportSuccess(sessionPayload);
 
@@ -185,7 +161,7 @@ describe("shopify", () => {
 
   it("prints available organizations and errors when multiple organizations are found without an id", async () => {
     const sessionPayload = sampleShopifyCliSessionPayload();
-    await writeShopifyCliConfig(sessionPayload, runtimeShopifyCliConfigLocation());
+    await writeShopifyCliConfig(sessionPayload);
 
     mockImportSuccess(sessionPayload);
 

--- a/spec/services/command/__snapshots__/app-identity.spec.ts.snap
+++ b/spec/services/command/__snapshots__/app-identity.spec.ts.snap
@@ -34,6 +34,8 @@ exports[`AppIdentity.load > production environment access > does not allow --env
 
 exports[`AppIdentity.load > production environment access > does not allow --env=production when the command is "push" 1`] = `[Error: You cannot "ggt push" your production environment.]`;
 
+exports[`AppIdentity.load > production environment access > does not allow --env=production when the command is "shopify" 1`] = `[Error: You cannot "ggt shopify" your production environment.]`;
+
 exports[`AppIdentity.load > production environment access > does not allow --env=production when the command is "status" 1`] = `[Error: You cannot "ggt status" your production environment.]`;
 
 exports[`AppIdentity.load > production environment access > does not allow --env=production when the command is "version" 1`] = `[Error: You cannot "ggt version" your production environment.]`;

--- a/src/commands/shopify.ts
+++ b/src/commands/shopify.ts
@@ -65,11 +65,16 @@ export default defineCommand({
   }),
 });
 
+// Mirrors Shopify CLI's conf/env-paths resolution for projectName "shopify-cli-kit":
+// - Windows: %APPDATA%\shopify-cli-kit-nodejs\Config\config.json
+// - macOS: ~/Library/Preferences/shopify-cli-kit-nodejs/config.json
+// - Linux/other: $XDG_CONFIG_HOME/shopify-cli-kit-nodejs/config.json (or ~/.config/...)
+// References:
+// - https://github.com/Shopify/cli/blob/3.91.0/packages/cli-kit/src/private/node/conf-store.ts
+// - https://github.com/sindresorhus/conf/blob/v13.1.0/source/index.ts
+// - https://github.com/sindresorhus/env-paths/blob/v3.0.0/index.js
 const getShopifyCliConfigPath = (): string => {
   if (config.windows) {
-    // Shopify CLI uses the `conf` npm package which delegates to `env-paths`.
-    // On Windows, env-paths resolves `config` to: path.join(APPDATA, name, "Config")
-    // See: https://github.com/Shopify/cli/blob/3.91.0/packages/cli-kit/src/public/node/local-storage.ts
     const appData = process.env["APPDATA"] ?? path.join(config.homeDir, "AppData", "Roaming");
     return path.join(appData, "shopify-cli-kit-nodejs", "Config", "config.json");
   }

--- a/src/commands/shopify.ts
+++ b/src/commands/shopify.ts
@@ -1,0 +1,207 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import chalk from "chalk";
+import pluralize from "pluralize";
+import type { JsonObject } from "type-fest";
+
+import {
+  CONNECT_SHOPIFY_MUTATION,
+  IMPORT_SHOPIFY_CLI_SESSION_MUTATION,
+  SHOPIFY_ORGANIZATIONS_QUERY,
+  type ShopifyOrganization,
+} from "../services/app/edit/operation.ts";
+import { defineCommand } from "../services/command/command.ts";
+import type { Context } from "../services/command/context.ts";
+import { FlagError, type FlagsResult } from "../services/command/flag.ts";
+import { config } from "../services/config/config.ts";
+import { UnknownDirectoryError } from "../services/filesync/error.ts";
+import { FileSync } from "../services/filesync/filesync.ts";
+import { SyncJson, SyncJsonFlags, loadSyncJsonDirectory } from "../services/filesync/sync-json.ts";
+import colors from "../services/output/colors.ts";
+import { println } from "../services/output/print.ts";
+import { sprint, sprintln } from "../services/output/sprint.ts";
+import { symbol } from "../services/output/symbols.ts";
+import { ts } from "../services/output/timestamp.ts";
+
+const SHOPIFY_AUTH_LOGIN_ERROR_MESSAGE = "Shopify CLI session not found. Run `shopify auth login` and try again.";
+
+const ConnectFlags = {
+  "--app-name": {
+    type: String,
+    description: "Shopify app name override",
+    details: "Defaults to your Gadget app slug.",
+  },
+  "--shopify-organization-id": {
+    type: String,
+    description: "Shopify organization ID to use when your account has multiple organizations",
+  },
+};
+
+type ConnectFlagsResult = FlagsResult<typeof SyncJsonFlags & typeof ConnectFlags>;
+
+export default defineCommand({
+  name: "shopify",
+  description: "Manage Shopify connection",
+  examples: ["ggt shopify connect", "ggt shopify connect --app-name my-shop"],
+  flags: SyncJsonFlags,
+  subcommands: (sub) => ({
+    connect: sub({
+      description: "Configure the Shopify connection for your application",
+      details: sprint`
+        Creates development and production Shopify app configs, adds the
+        default Shopify models, and adds the required default Shopify scopes.
+      `,
+      examples: [
+        "ggt shopify connect",
+        "ggt shopify connect --app-name my-shop",
+        "ggt shopify connect --shopify-organization-id 123456789",
+      ],
+      flags: ConnectFlags,
+      run: async (ctx, flags) => {
+        await runConnect(ctx, flags);
+      },
+    }),
+  }),
+});
+
+const getShopifyCliConfigPath = (): string => {
+  if (config.windows) {
+    // Shopify CLI uses the `conf` npm package which delegates to `env-paths`.
+    // On Windows, env-paths resolves `config` to: path.join(APPDATA, name, "Config")
+    // See: https://github.com/Shopify/cli/blob/3.91.0/packages/cli-kit/src/public/node/local-storage.ts
+    const appData = process.env["APPDATA"] ?? path.join(config.homeDir, "AppData", "Roaming");
+    return path.join(appData, "shopify-cli-kit-nodejs", "Config", "config.json");
+  }
+
+  const xdgConfigHome = process.env["XDG_CONFIG_HOME"];
+  if (xdgConfigHome) {
+    return path.join(xdgConfigHome, "shopify-cli-kit-nodejs", "config.json");
+  }
+
+  if (config.macos) {
+    return path.join(config.homeDir, "Library", "Preferences", "shopify-cli-kit-nodejs", "config.json");
+  }
+
+  return path.join(config.homeDir, ".config", "shopify-cli-kit-nodejs", "config.json");
+};
+
+const loadShopifyCliSessionPayload = async (): Promise<JsonObject> => {
+  const configPath = getShopifyCliConfigPath();
+  let configFileContent: string;
+
+  try {
+    configFileContent = await fs.readFile(configPath, "utf8");
+  } catch {
+    throw new FlagError(SHOPIFY_AUTH_LOGIN_ERROR_MESSAGE, { usageHint: false });
+  }
+
+  try {
+    const configJson = JSON.parse(configFileContent) as { sessionStore?: unknown };
+    if (typeof configJson.sessionStore !== "string") {
+      throw new Error("Missing sessionStore");
+    }
+
+    const sessionPayload = JSON.parse(configJson.sessionStore);
+    if (!sessionPayload || typeof sessionPayload !== "object") {
+      throw new Error("Invalid session payload");
+    }
+
+    return sessionPayload as JsonObject;
+  } catch {
+    throw new FlagError(SHOPIFY_AUTH_LOGIN_ERROR_MESSAGE, { usageHint: false });
+  }
+};
+
+const printShopifyOrganizations = (organizations: ShopifyOrganization[]): void => {
+  println({ ensureEmptyLineAbove: true, content: "Shopify organizations available:" });
+  for (const organization of organizations) {
+    println({ content: `  - ${organization.id}: ${organization.name} (${organization.platform})` });
+  }
+};
+
+const resolveShopifyOrganizationId = async (syncJson: SyncJson, providedOrganizationId?: string): Promise<string> => {
+  if (providedOrganizationId) {
+    return providedOrganizationId;
+  }
+
+  const organizations = (await syncJson.edit.query({ query: SHOPIFY_ORGANIZATIONS_QUERY })).shopifyOrganizations;
+
+  if (organizations.length === 0) {
+    throw new FlagError("No Shopify organizations were found for your account. Run `shopify auth login` and try again.", {
+      usageHint: false,
+    });
+  }
+
+  if (organizations.length === 1) {
+    const organization = organizations[0];
+    return organization.id;
+  }
+
+  printShopifyOrganizations(organizations);
+  throw new FlagError("Multiple Shopify organizations found. Re-run with --shopify-organization-id <id>.", {
+    usageHint: false,
+  });
+};
+
+const runConnect = async (ctx: Context, flags: ConnectFlagsResult): Promise<void> => {
+  const directory = await loadSyncJsonDirectory(process.cwd());
+  const syncJson = await SyncJson.load(ctx, { command: "shopify", flags, directory });
+  if (!syncJson) {
+    throw new UnknownDirectoryError({ command: "shopify", flags, directory });
+  }
+
+  const shopifyCliSessionPayload = await loadShopifyCliSessionPayload();
+  const importResult = await syncJson.edit.mutate({
+    mutation: IMPORT_SHOPIFY_CLI_SESSION_MUTATION,
+    variables: { configSessionPayload: shopifyCliSessionPayload },
+  });
+
+  if (!importResult.importShopifyCliSession.success) {
+    throw new FlagError("Failed to import Shopify CLI session. Run `shopify auth login` and try again.", {
+      usageHint: false,
+    });
+  }
+
+  const filesync = new FileSync(syncJson);
+  const hashes = await filesync.hashes(ctx, { silent: true });
+
+  if (!hashes.inSync) {
+    await filesync.merge(ctx, {
+      hashes,
+      printEnvironmentChangesOptions: { limit: 5 },
+      printLocalChangesOptions: { limit: 5 },
+      silent: true,
+    });
+    println({ ensureEmptyLineAbove: true, content: `${chalk.greenBright(symbol.tick)} Sync completed ${ts()}` });
+  }
+
+  const appName = flags["--app-name"] ?? syncJson.application.slug;
+  const shopifyOrganizationId = await resolveShopifyOrganizationId(syncJson, flags["--shopify-organization-id"]);
+
+  const result = (
+    await syncJson.edit.mutate({
+      mutation: CONNECT_SHOPIFY_MUTATION,
+      variables: { appName, shopifyOrganizationId },
+    })
+  ).connectShopify;
+
+  const totalChanges = result.changed.length + result.deleted.length;
+
+  await filesync.writeToLocalFilesystem(ctx, {
+    filesVersion: result.remoteFilesVersion,
+    files: result.changed,
+    delete: result.deleted.map((file) => file.path),
+    printEnvironmentChangesOptions: {
+      tense: "past",
+      ensureEmptyLineAbove: true,
+      title: sprintln`${colors.created(symbol.tick)} Created Shopify connection ${pluralize("file", totalChanges)}. ${ts()}`,
+      limit: 5,
+    },
+  });
+
+  println({
+    ensureEmptyLineAbove: true,
+    content: `${chalk.greenBright(symbol.tick)} Shopify connection configured successfully.`,
+  });
+};

--- a/src/services/app/edit/operation.ts
+++ b/src/services/app/edit/operation.ts
@@ -19,6 +19,7 @@ import type {
   EnvironmentLogsSubscriptionVariables,
   EnvironmentVariablesQuery,
   EnvironmentVariablesQueryVariables,
+  FileSyncEncoding,
   FileSyncComparisonHashesQuery,
   FileSyncComparisonHashesQueryVariables,
   FileSyncFilesQuery,
@@ -233,6 +234,82 @@ export const PUBLISH_STATUS_SUBSCRIPTION = sprint(/* GraphQL */ `
 `) as GraphQLSubscription<PublishStatusSubscription, PublishStatusSubscriptionVariables>;
 
 export type PUBLISH_STATUS_SUBSCRIPTION = typeof PUBLISH_STATUS_SUBSCRIPTION;
+
+type ImportShopifyCliSessionMutation = {
+  importShopifyCliSession: {
+    success: boolean;
+  };
+};
+
+type ImportShopifyCliSessionMutationVariables = {
+  configSessionPayload: JsonObject;
+};
+
+export const IMPORT_SHOPIFY_CLI_SESSION_MUTATION = sprint(/* GraphQL */ `
+  mutation ImportShopifyCliSession($configSessionPayload: JSON!) {
+    importShopifyCliSession(configSessionPayload: $configSessionPayload) {
+      success
+    }
+  }
+`) as GraphQLMutation<ImportShopifyCliSessionMutation, ImportShopifyCliSessionMutationVariables>;
+
+export type IMPORT_SHOPIFY_CLI_SESSION_MUTATION = typeof IMPORT_SHOPIFY_CLI_SESSION_MUTATION;
+
+export type ShopifyOrganization = {
+  id: string;
+  name: string;
+  platform: string;
+};
+
+type ShopifyOrganizationsQuery = {
+  shopifyOrganizations: ShopifyOrganization[];
+};
+
+type ShopifyOrganizationsQueryVariables = Record<string, never>;
+
+export const SHOPIFY_ORGANIZATIONS_QUERY = sprint(/* GraphQL */ `
+  query ShopifyOrganizations {
+    shopifyOrganizations {
+      id
+      name
+      platform
+    }
+  }
+`) as GraphQLQuery<ShopifyOrganizationsQuery, ShopifyOrganizationsQueryVariables>;
+
+export type SHOPIFY_ORGANIZATIONS_QUERY = typeof SHOPIFY_ORGANIZATIONS_QUERY;
+
+type ConnectShopifyMutation = {
+  connectShopify: {
+    remoteFilesVersion: string;
+    changed: { path: string; mode: number; content: string; encoding: FileSyncEncoding }[];
+    deleted: { path: string }[];
+  };
+};
+
+type ConnectShopifyMutationVariables = {
+  appName: string;
+  shopifyOrganizationId?: string;
+};
+
+export const CONNECT_SHOPIFY_MUTATION = sprint(/* GraphQL */ `
+  mutation ConnectShopify($appName: String!, $shopifyOrganizationId: String) {
+    connectShopify(appName: $appName, shopifyOrganizationId: $shopifyOrganizationId) {
+      remoteFilesVersion
+      changed {
+        path
+        mode
+        content
+        encoding
+      }
+      deleted {
+        path
+      }
+    }
+  }
+`) as GraphQLMutation<ConnectShopifyMutation, ConnectShopifyMutationVariables>;
+
+export type CONNECT_SHOPIFY_MUTATION = typeof CONNECT_SHOPIFY_MUTATION;
 
 export const CREATE_MODEL_MUTATION = sprint(/* GraphQL */ `
   mutation createModel($path: String!, $fields: [CreateModelFieldsInput!]) {

--- a/src/services/command/command.ts
+++ b/src/services/command/command.ts
@@ -26,6 +26,7 @@ export const Commands = [
   "model",
   "action",
   "field",
+  "shopify",
   "open",
   "list",
   "login",
@@ -228,6 +229,9 @@ export const importCommand = async (cmd: Command): Promise<CommandConfig> => {
     case "field":
       module = await import("../../commands/field.ts");
       break;
+    case "shopify":
+      module = await import("../../commands/shopify.ts");
+      break;
     case "open":
       module = await import("../../commands/open.ts");
       break;
@@ -275,7 +279,7 @@ export const importCommand = async (cmd: Command): Promise<CommandConfig> => {
 /** Command group definitions for root help display. */
 export const commandGroups: readonly { label: string; commands: readonly Command[] }[] = [
   { label: "Development", commands: ["dev", "deploy", "push", "pull", "status", "logs", "debugger"] },
-  { label: "Resources", commands: ["add", "model", "action", "field", "var", "env", "open"] },
+  { label: "Resources", commands: ["add", "model", "action", "field", "shopify", "var", "env", "open"] },
   { label: "Account", commands: ["login", "logout", "whoami", "list"] },
   { label: "Diagnostics", commands: ["problems", "eval"] },
   { label: "Configuration", commands: ["configure", "agent-plugin", "completion", "version"] },


### PR DESCRIPTION
Add a new ggt shopify connect command.

Should only be merged after https://github.com/gadget-inc/gadget/pull/20042 is merged


Flow:
1. Check to see if the user has run `shopify auth login` and has a cli session payload on their fs. If not, error and ask them to run `shopify auth login`
2. Import the the session payload into the Gadget monorepo if it exists
3. Using the imported session payload, query the Shopify API for the organizations the user is a part of. If there is just one, continue. If there are more than 1, output all of them along with their IDs and ask the user to re-run the command targeting a particular Shopify organization
4. Call the `connectShopify` mutation in the monorepo