### PR TITLE
Fix ENOENT race condition crash in `ggt dev` file sync

### DIFF
--- a/.changeset/fix-enoent-race-in-dev.md
+++ b/.changeset/fix-enoent-race-in-dev.md
@@ -1,0 +1,7 @@
+---
+"ggt": patch
+---
+
+Fix crash during `ggt dev` when a file is deleted between stat and read
+
+Handle ENOENT errors from `fs.readFile()` in `_sendChangesToEnvironment` the same way they're already handled for `fs.stat()` — by skipping the file instead of crashing the session.

--- a/spec/services/filesync/filesync.spec.ts
+++ b/spec/services/filesync/filesync.spec.ts
@@ -544,6 +544,29 @@ describe("FileSync._sendChangesToEnvironment", () => {
     expect(nock.pendingMocks()).toEqual([]);
   });
 
+  it("skips files deleted between stat and read (race condition)", async () => {
+    const changes = new Changes();
+    changes.set("file.txt", { type: "create" });
+
+    // Simulate the race: stat succeeds, then file is deleted before readFile.
+    // Mock stat to return a file Stats, but don't create the file on disk.
+    const originalStat = fs.stat.bind(fs);
+    // oxlint-disable-next-line no-misused-promises
+    vi.spyOn(fs, "stat").mockImplementation(async (filepath, ...args) => {
+      // For our test file, return a fake stat indicating it's a regular file
+      if (String(filepath).endsWith("file.txt")) {
+        return { isFile: () => true, isDirectory: () => false, mode: 0o644 } as fs.Stats;
+      }
+      return originalStat(filepath, ...args) as unknown as fs.Stats;
+    });
+
+    // Should not throw — the ENOENT should be swallowed
+    await sendChangesToGadget(testCtx, { changes });
+
+    // No GraphQL call should have been made since the only file was skipped
+    expect(nock.pendingMocks()).toEqual([]);
+  });
+
   it("retries failed graphql requests", async () => {
     await writeDir(localDir, {
       "foo.js": "// foo",

--- a/src/services/filesync/filesync.ts
+++ b/src/services/filesync/filesync.ts
@@ -841,7 +841,13 @@ export class FileSync {
 
       let content = "";
       if (stats.isFile()) {
-        content = await fs.readFile(absolutePath, FileSyncEncoding.Base64);
+        try {
+          content = await fs.readFile(absolutePath, FileSyncEncoding.Base64);
+        } catch (error) {
+          swallowEnoent(error);
+          ctx.log.debug("skipping change because file was deleted after stat", { path: normalizedPath });
+          return;
+        }
       }
 
       let oldPath;


### PR DESCRIPTION
## Summary

In `_sendChangesToEnvironment`, the `fs.stat()` call is wrapped in a try-catch that swallows ENOENT (file deleted before we read it), but the subsequent `fs.readFile()` is not. If a file is deleted between the two calls -- a common race when editors or build tools write temp files -- the unhandled ENOENT bubbles up as an `UnexpectedError`, crashing the dev session and reporting to Sentry as a bug.

This wraps `fs.readFile()` in the same ENOENT-swallowing pattern already used for `fs.stat()`, so the file is silently skipped instead of crashing.

Fixes GGT-T7

## Test plan

- [x] Regression test: mocks `fs.stat` to return a fake Stats for a non-existent file, confirming `fs.readFile` ENOENT is swallowed and no GraphQL call is made
- [x] All 65 existing filesync tests pass
- [x] Lint clean