### PR TITLE
Add `ggt shopify status` command

### DIFF
--- a/.changeset/shopify-status-command.md
+++ b/.changeset/shopify-status-command.md
@@ -1,0 +1,9 @@
+---
+"ggt": minor
+---
+
+Add `ggt shopify status` to show the status of your Gadget app's Shopify connection.
+
+The command prints your current Shopify API version (and whether a newer
+version is available), the enabled Shopify models, the authenticated
+Shopify partner account, and the connected Shopify app's name and client id.

--- a/spec/commands/__snapshots__/completion.spec.ts.snap
+++ b/spec/commands/__snapshots__/completion.spec.ts.snap
@@ -297,11 +297,14 @@ _ggt_completions() {
       done
 
       if [[ -z "$sub_cmd" ]]; then
-        COMPREPLY=($(compgen -W "connect --application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --help -h --version --verbose -v --telemetry --json" -- "$cur"))
+        COMPREPLY=($(compgen -W "connect status --application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --help -h --version --verbose -v --telemetry --json" -- "$cur"))
       else
         case "$sub_cmd" in
           connect)
             COMPREPLY=($(compgen -W "--application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --app-name --shopify-organization-id --help -h --version --verbose -v --telemetry --json" -- "$cur"))
+            ;;
+          status)
+            COMPREPLY=($(compgen -W "--application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --help -h --version --verbose -v --telemetry --json" -- "$cur"))
             ;;
           *)
             COMPREPLY=($(compgen -W "--application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --help -h --version --verbose -v --telemetry --json" -- "$cur"))
@@ -928,18 +931,24 @@ complete -c ggt -n '__fish_seen_subcommand_from shopify' -l allow-unknown-direct
 complete -c ggt -n '__fish_seen_subcommand_from shopify' -l allow -x -d 'Enable allow flags (comma-separated)'
 complete -c ggt -n '__fish_seen_subcommand_from shopify' -l allow-all -d 'Enable all --allow-* flags'
 complete -c ggt -n '__ggt_needs_subcommand shopify -- --application -a --app --environment -e --env --allow' -a 'connect' -d 'Configure the Shopify connection for your application'
+complete -c ggt -n '__ggt_needs_subcommand shopify -- --application -a --app --environment -e --env --allow' -a 'status' -d 'Show the status of your Shopify connection'
 complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l app-name -x -d 'Shopify app name override'
 complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l shopify-organization-id -x -d 'Shopify organization ID to use when your account has multiple organizations'
 complete -c ggt -n '__fish_seen_subcommand_from shopify' -l help -s h -d 'Show command help'
 complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l help -s h -d 'Show command help'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- status -- --application -a --app --environment -e --env --allow' -l help -s h -d 'Show command help'
 complete -c ggt -n '__fish_seen_subcommand_from shopify' -l version -d 'Print the ggt version'
 complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l version -d 'Print the ggt version'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- status -- --application -a --app --environment -e --env --allow' -l version -d 'Print the ggt version'
 complete -c ggt -n '__fish_seen_subcommand_from shopify' -l verbose -s v -d 'Increase output verbosity (-vv for debug, -vvv for trace)'
 complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l verbose -s v -d 'Increase output verbosity (-vv for debug, -vvv for trace)'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- status -- --application -a --app --environment -e --env --allow' -l verbose -s v -d 'Increase output verbosity (-vv for debug, -vvv for trace)'
 complete -c ggt -n '__fish_seen_subcommand_from shopify' -l telemetry -d 'Enable telemetry'
 complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l telemetry -d 'Enable telemetry'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- status -- --application -a --app --environment -e --env --allow' -l telemetry -d 'Enable telemetry'
 complete -c ggt -n '__fish_seen_subcommand_from shopify' -l json -d 'Output as JSON where supported'
 complete -c ggt -n '__ggt_seen_subcommand shopify -- connect -- --application -a --app --environment -e --env --allow' -l json -d 'Output as JSON where supported'
+complete -c ggt -n '__ggt_seen_subcommand shopify -- status -- --application -a --app --environment -e --env --allow' -l json -d 'Output as JSON where supported'
 
 # open
 complete -c ggt -n '__fish_seen_subcommand_from open' -l application -s a -rfa '(__ggt_complete)' -d 'Gadget app to use'
@@ -1787,6 +1796,7 @@ _ggt_shopify() {
     subcommand)
       subcommands=(
         'connect:Configure the Shopify connection for your application'
+        'status:Show the status of your Shopify connection'
       )
       _describe -t subcommands 'shopify subcommand' subcommands
       ;;
@@ -1813,6 +1823,26 @@ _ggt_shopify() {
             '--allow-all[Enable all --allow-* flags]' \\
             '--app-name[Shopify app name override]:value: ' \\
             '--shopify-organization-id[Shopify organization ID to use when your account has multiple organizations]:value: '
+          ;;
+        status)
+          _arguments \\
+            '(--help -h)''--help[Show command help]' \\
+            '(--help -h)''-h[Show command help]' \\
+            '--version[Print the ggt version]' \\
+            '(--verbose -v)''--verbose[Increase output verbosity (-vv for debug, -vvv for trace)]' \\
+            '(--verbose -v)''-v[Increase output verbosity (-vv for debug, -vvv for trace)]' \\
+            '--telemetry[Enable telemetry]' \\
+            '--json[Output as JSON where supported]' \\
+            '(--application -a --app)''--application[Gadget app to use]:value:_ggt_dynamic' \\
+            '(--application -a --app)''-a[Gadget app to use]:value:_ggt_dynamic' \\
+            '(--application -a --app)''--app[Gadget app to use]:value:_ggt_dynamic' \\
+            '(--environment -e --env)''--environment[Environment to use]:value:_ggt_dynamic' \\
+            '(--environment -e --env)''-e[Environment to use]:value:_ggt_dynamic' \\
+            '(--environment -e --env)''--env[Environment to use]:value:_ggt_dynamic' \\
+            '--allow-different-app[Allow syncing with a different app]' \\
+            '--allow-unknown-directory[Allow syncing to an existing directory]' \\
+            '--allow[Enable allow flags (comma-separated)]:value: ' \\
+            '--allow-all[Enable all --allow-* flags]'
           ;;
       esac
       ;;

--- a/spec/commands/__snapshots__/root.spec.ts.snap
+++ b/spec/commands/__snapshots__/root.spec.ts.snap
@@ -2931,6 +2931,64 @@ Run ggt shopify connect --help for more information.
 "
 `;
 
+exports[`root > when shopify is given > prints the usage for status when --help is passed 1`] = `
+"Show the status of your Shopify connection
+
+Shows your current Shopify API version, enabled Shopify models,
+authenticated Shopify account, and app/client id details.
+
+USAGE
+  ggt shopify status [flags]
+
+FLAGS
+  -a, --app, --application <app>
+        Gadget app to use. The app slug is the subdomain portion of your app URL
+        (e.g., my-app from my-app.gadget.app). Can be omitted when
+        .gadget/sync.json already records the app.
+
+  -e, --env, --environment <env>
+        Environment to use. Defaults to the development environment. Production
+        is read-only for most commands.
+
+ADDITIONAL FLAGS
+      --allow <flag,...>
+        Enable allow flags (comma-separated)
+
+      --allow-all
+        Enable all --allow-* flags
+
+      --allow-different-app
+        Allow syncing with a different app. Overrides the app recorded in
+        .gadget/sync.json with the one specified by --app. Use this when you
+        want to reuse an existing directory for a different app.
+
+      --allow-unknown-directory
+        Allow syncing to an existing directory. Normally, a directory must be
+        empty or already contain .gadget/sync.json. Use this when you want to
+        initialize sync in a directory with existing content.
+
+EXAMPLES
+  $ ggt shopify status
+"
+`;
+
+exports[`root > when shopify is given > prints the usage for status when -h is passed 1`] = `
+"Show the status of your Shopify connection
+
+USAGE
+  ggt shopify status [flags]
+
+FLAGS
+  -a, --app, --application <app>  Gadget app to use
+  -e, --env, --environment <env>  Environment to use
+
+EXAMPLES
+  $ ggt shopify status
+
+Run ggt shopify status --help for more information.
+"
+`;
+
 exports[`root > when shopify is given > prints the usage when --help is passed 1`] = `
 "Manage Shopify connection
 
@@ -2939,6 +2997,7 @@ USAGE
 
 COMMANDS
   connect    Configure the Shopify connection for your application
+  status     Show the status of your Shopify connection
 
 FLAGS
   -a, --app, --application <app>
@@ -2969,6 +3028,7 @@ ADDITIONAL FLAGS
 
 EXAMPLES
   $ ggt shopify connect
+  $ ggt shopify status
   $ ggt shopify connect --app-name my-shop
 "
 `;
@@ -2981,6 +3041,7 @@ USAGE
 
 COMMANDS
   connect    Configure the Shopify connection for your application
+  status     Show the status of your Shopify connection
 
 FLAGS
   -a, --app, --application <app>  Gadget app to use
@@ -2988,6 +3049,7 @@ FLAGS
 
 EXAMPLES
   $ ggt shopify connect
+  $ ggt shopify status
   $ ggt shopify connect --app-name my-shop
 
 Run ggt shopify --help for more information.
@@ -3002,6 +3064,7 @@ USAGE
 
 COMMANDS
   connect    Configure the Shopify connection for your application
+  status     Show the status of your Shopify connection
 
 FLAGS
   -a, --app, --application <app>  Gadget app to use
@@ -3009,6 +3072,7 @@ FLAGS
 
 EXAMPLES
   $ ggt shopify connect
+  $ ggt shopify status
   $ ggt shopify connect --app-name my-shop
 
 Run ggt shopify --help for more information.

--- a/spec/commands/shopify.spec.ts
+++ b/spec/commands/shopify.spec.ts
@@ -9,6 +9,7 @@ import {
   CONNECT_SHOPIFY_MUTATION,
   IMPORT_SHOPIFY_CLI_SESSION_MUTATION,
   SHOPIFY_ORGANIZATIONS_QUERY,
+  SHOPIFY_STATUS_QUERY,
 } from "../../src/services/app/edit/operation.ts";
 import { runCommand } from "../../src/services/command/run.ts";
 import { config } from "../../src/services/config/config.ts";
@@ -87,6 +88,14 @@ const mockConnectSuccess = (appName: string, shopifyOrganizationId: string) =>
     expectVariables: { appName, shopifyOrganizationId },
   });
 
+const mockStatusResponse = (response: (typeof SHOPIFY_STATUS_QUERY)["Data"]) =>
+  nockEditResponse({
+    operation: SHOPIFY_STATUS_QUERY,
+    response: {
+      data: response,
+    },
+  });
+
 describe("shopify", () => {
   beforeEach(async () => {
     loginTestUser();
@@ -119,6 +128,26 @@ describe("shopify", () => {
     await runCommand(testCtx, shopify, "connect", "--app-name", "custom-shopify-app", "--shopify-organization-id", "org-2");
 
     expectStdout().toContain("Shopify connection configured successfully");
+  });
+
+  it("prints Shopify status details", async () => {
+    mockStatusResponse({
+      shopifyIdentityConnectionState: { isConnected: true, email: "shardul@gadget.dev" },
+      shopifyConnection: {
+        apiVersion: "2024-04",
+        latestApiVersion: "2026-04",
+        apiVersionUpToDate: false,
+        enabledModels: ["shopifyProduct", "shopifyVariant"],
+        canonicalApp: { appName: "my-gadget-app", clientId: "abc123" },
+      },
+    });
+
+    await runCommand(testCtx, shopify, "status");
+
+    expectStdout().toContain("2024-04 (2026-04 available)");
+    expectStdout().toContain("shopifyProduct | shopifyVariant");
+    expectStdout().toContain("shardul@gadget.dev");
+    expectStdout().toContain("my-gadget-app (client_id: abc123)");
   });
 
   it("errors with auth login guidance when Shopify CLI config is missing", async () => {

--- a/src/commands/shopify.ts
+++ b/src/commands/shopify.ts
@@ -9,6 +9,7 @@ import {
   CONNECT_SHOPIFY_MUTATION,
   IMPORT_SHOPIFY_CLI_SESSION_MUTATION,
   SHOPIFY_ORGANIZATIONS_QUERY,
+  SHOPIFY_STATUS_QUERY,
   type ShopifyOrganization,
 } from "../services/app/edit/operation.ts";
 import { defineCommand } from "../services/command/command.ts";
@@ -25,6 +26,7 @@ import { symbol } from "../services/output/symbols.ts";
 import { ts } from "../services/output/timestamp.ts";
 
 const SHOPIFY_AUTH_LOGIN_ERROR_MESSAGE = "Shopify CLI session not found. Run `shopify auth login` and try again.";
+const STATUS_LABEL_WIDTH = 24;
 
 const ConnectFlags = {
   "--app-name": {
@@ -39,11 +41,12 @@ const ConnectFlags = {
 };
 
 type ConnectFlagsResult = FlagsResult<typeof SyncJsonFlags & typeof ConnectFlags>;
+type StatusFlagsResult = FlagsResult<typeof SyncJsonFlags>;
 
 export default defineCommand({
   name: "shopify",
   description: "Manage Shopify connection",
-  examples: ["ggt shopify connect", "ggt shopify connect --app-name my-shop"],
+  examples: ["ggt shopify connect", "ggt shopify status", "ggt shopify connect --app-name my-shop"],
   flags: SyncJsonFlags,
   subcommands: (sub) => ({
     connect: sub({
@@ -60,6 +63,17 @@ export default defineCommand({
       flags: ConnectFlags,
       run: async (ctx, flags) => {
         await runConnect(ctx, flags);
+      },
+    }),
+    status: sub({
+      description: "Show the status of your Shopify connection",
+      details: sprint`
+        Shows your current Shopify API version, enabled Shopify models,
+        authenticated Shopify account, and app/client id details.
+      `,
+      examples: ["ggt shopify status"],
+      run: async (ctx, flags) => {
+        await runStatus(ctx, flags);
       },
     }),
   }),
@@ -147,6 +161,41 @@ const resolveShopifyOrganizationId = async (syncJson: SyncJson, providedOrganiza
   throw new FlagError("Multiple Shopify organizations found. Re-run with --shopify-organization-id <id>.", {
     usageHint: false,
   });
+};
+
+const statusLine = (label: string, value: string): string => `${label.padEnd(STATUS_LABEL_WIDTH)}${value}`;
+
+const runStatus = async (ctx: Context, flags: StatusFlagsResult): Promise<void> => {
+  const directory = await loadSyncJsonDirectory(process.cwd());
+  const syncJson = await SyncJson.load(ctx, { command: "shopify", flags, directory });
+  if (!syncJson) {
+    throw new UnknownDirectoryError({ command: "shopify", flags, directory });
+  }
+
+  const { shopifyIdentityConnectionState: identity, shopifyConnection: conn } = await syncJson.edit.query({
+    query: SHOPIFY_STATUS_QUERY,
+  });
+
+  const apiVersion = conn
+    ? conn.apiVersionUpToDate
+      ? conn.apiVersion
+      : `${conn.apiVersion} (${conn.latestApiVersion} available)`
+    : "Not configured";
+
+  const models = conn && conn.enabledModels.length > 0 ? conn.enabledModels.join(" | ") : "None";
+
+  const account = identity.isConnected ? (identity.email ?? "Connected (email unavailable)") : "Not connected";
+
+  const app = conn?.canonicalApp
+    ? conn.canonicalApp.appName
+      ? `${conn.canonicalApp.appName} (client_id: ${conn.canonicalApp.clientId})`
+      : `client_id: ${conn.canonicalApp.clientId}`
+    : "Not configured";
+
+  println({ ensureEmptyLineAbove: true, content: statusLine("API version:", apiVersion) });
+  println({ content: statusLine("Enabled models:", models) });
+  println({ content: statusLine("Authed partner account:", account) });
+  println({ content: statusLine("App:", app) });
 };
 
 const runConnect = async (ctx: Context, flags: ConnectFlagsResult): Promise<void> => {

--- a/src/services/app/edit/operation.ts
+++ b/src/services/app/edit/operation.ts
@@ -279,6 +279,42 @@ export const SHOPIFY_ORGANIZATIONS_QUERY = sprint(/* GraphQL */ `
 
 export type SHOPIFY_ORGANIZATIONS_QUERY = typeof SHOPIFY_ORGANIZATIONS_QUERY;
 
+export type ShopifyConnectionStatus = {
+  apiVersion: string;
+  latestApiVersion: string;
+  apiVersionUpToDate: boolean;
+  enabledModels: string[];
+  canonicalApp: { appName: string | null; clientId: string } | null;
+};
+
+type ShopifyStatusQuery = {
+  shopifyIdentityConnectionState: { isConnected: boolean; email: string | null };
+  shopifyConnection: ShopifyConnectionStatus | null;
+};
+
+type ShopifyStatusQueryVariables = Record<string, never>;
+
+export const SHOPIFY_STATUS_QUERY = sprint(/* GraphQL */ `
+  query ShopifyStatus {
+    shopifyIdentityConnectionState {
+      isConnected
+      email
+    }
+    shopifyConnection {
+      apiVersion
+      latestApiVersion
+      apiVersionUpToDate
+      enabledModels
+      canonicalApp {
+        appName
+        clientId
+      }
+    }
+  }
+`) as GraphQLQuery<ShopifyStatusQuery, ShopifyStatusQueryVariables>;
+
+export type SHOPIFY_STATUS_QUERY = typeof SHOPIFY_STATUS_QUERY;
+
 /**
  * Common return shape for mutations that modify files and return sync events.
  * Matches the GraphQL `RemoteFileSyncEvents` type.
@@ -295,11 +331,11 @@ type ConnectShopifyMutation = {
 
 type ConnectShopifyMutationVariables = {
   appName: string;
-  shopifyOrganizationId?: string;
+  shopifyOrganizationId: string;
 };
 
 export const CONNECT_SHOPIFY_MUTATION = sprint(/* GraphQL */ `
-  mutation ConnectShopify($appName: String!, $shopifyOrganizationId: String) {
+  mutation ConnectShopify($appName: String!, $shopifyOrganizationId: String!) {
     connectShopify(appName: $appName, shopifyOrganizationId: $shopifyOrganizationId) {
       remoteFilesVersion
       changed {


### PR DESCRIPTION
Example:

```
shardul@turbogadget ~/D/g/t/a/shopify-status-production> ggt shopify status
API version:            2026-04
Enabled models:         shopifyGdprRequest | shopifyShop | shopifySync
Authed partner account: shardul@gadget.dev
App:                    shardul-shop-order-viewer-deve (client_id: 5d1079ad9241c297a762086eeaab8847)
```