### PR TITLE
Add scopes and webhook topics to `ggt shopify status`

### DIFF
--- a/.changeset/shopify-status-scopes-webhooks.md
+++ b/.changeset/shopify-status-scopes-webhooks.md
@@ -1,0 +1,5 @@
+---
+"ggt": minor
+---
+
+Add requested scopes and webhook topics to `ggt shopify status`.

--- a/spec/commands/shopify.spec.ts
+++ b/spec/commands/shopify.spec.ts
@@ -139,6 +139,8 @@ describe("shopify", () => {
         apiVersionUpToDate: false,
         enabledModels: ["shopifyProduct", "shopifyVariant"],
         canonicalApp: { appName: "my-gadget-app", clientId: "abc123" },
+        scopes: ["read_orders", "write_products"],
+        webhookTopics: ["app/uninstalled", "orders/create", "orders/updated"],
       },
     });
 
@@ -148,6 +150,8 @@ describe("shopify", () => {
     expectStdout().toContain("shopifyProduct | shopifyVariant");
     expectStdout().toContain("shardul@gadget.dev");
     expectStdout().toContain("my-gadget-app (client_id: abc123)");
+    expectStdout().toContain("read_orders | write_products");
+    expectStdout().toContain("app/uninstalled | orders/create | orders/updated");
   });
 
   it("errors with auth login guidance when Shopify CLI config is missing", async () => {

--- a/src/commands/shopify.ts
+++ b/src/commands/shopify.ts
@@ -192,10 +192,16 @@ const runStatus = async (ctx: Context, flags: StatusFlagsResult): Promise<void> 
       : `client_id: ${conn.canonicalApp.clientId}`
     : "Not configured";
 
+  const scopes = conn ? (conn.scopes.length > 0 ? conn.scopes.join(" | ") : "None") : "Not configured";
+
+  const webhookTopics = conn ? (conn.webhookTopics.length > 0 ? conn.webhookTopics.join(" | ") : "None") : "Not configured";
+
   println({ ensureEmptyLineAbove: true, content: statusLine("API version:", apiVersion) });
   println({ content: statusLine("Enabled models:", models) });
   println({ content: statusLine("Authed partner account:", account) });
   println({ content: statusLine("App:", app) });
+  println({ content: statusLine("Scopes:", scopes) });
+  println({ content: statusLine("Webhook topics:", webhookTopics) });
 };
 
 const runConnect = async (ctx: Context, flags: ConnectFlagsResult): Promise<void> => {

--- a/src/services/app/edit/operation.ts
+++ b/src/services/app/edit/operation.ts
@@ -285,6 +285,8 @@ export type ShopifyConnectionStatus = {
   apiVersionUpToDate: boolean;
   enabledModels: string[];
   canonicalApp: { appName: string | null; clientId: string } | null;
+  scopes: string[];
+  webhookTopics: string[];
 };
 
 type ShopifyStatusQuery = {
@@ -309,6 +311,8 @@ export const SHOPIFY_STATUS_QUERY = sprint(/* GraphQL */ `
         appName
         clientId
       }
+      scopes
+      webhookTopics
     }
   }
 `) as GraphQLQuery<ShopifyStatusQuery, ShopifyStatusQueryVariables>;


### PR DESCRIPTION
https://github.com/gadget-inc/gadget/pull/20487 Must be merged first

Adds the list of enabled scopes and webhook topics in the output of `ggt shopify status`