### PR TITLE
Add --required, --unique, and --metafield flags to ggt field add

### DIFF
--- a/.changeset/field-add-flags.md
+++ b/.changeset/field-add-flags.md
@@ -1,0 +1,7 @@
+---
+"ggt": minor
+---
+
+Add `--required`, `--unique`, and `--metafield` flags to `ggt field add`. The
+`--metafield` flag links a field to a Shopify metafield and accepts
+`--namespace`, `--key`, `--metafield-type`, and `--list`.

--- a/spec/commands/__snapshots__/completion.spec.ts.snap
+++ b/spec/commands/__snapshots__/completion.spec.ts.snap
@@ -16,7 +16,7 @@ _ggt_completions() {
     --from-file)
       COMPREPLY=($(compgen -f -- "$cur"))
       return ;;
-    --file-push-delay|--file-watch-debounce|--file-watch-poll-interval|--file-watch-poll-timeout|--file-watch-rename-timeout|--allow|--type|--resource|--model|--app-name|--shopify-organization-id|--start|--port|-p)
+    --file-push-delay|--file-watch-debounce|--file-watch-poll-interval|--file-watch-poll-timeout|--file-watch-rename-timeout|--allow|--type|--resource|--model|--namespace|--key|--metafield-type|--app-name|--shopify-organization-id|--start|--port|-p)
       return ;;
   esac
 
@@ -264,7 +264,7 @@ _ggt_completions() {
       else
         case "$sub_cmd" in
           add)
-            COMPREPLY=($(compgen -W "--application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --help -h --version --verbose -v --telemetry --json" -- "$cur"))
+            COMPREPLY=($(compgen -W "--application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --required --unique --metafield --namespace --key --metafield-type --list --help -h --version --verbose -v --telemetry --json" -- "$cur"))
             ;;
           remove)
             COMPREPLY=($(compgen -W "--application -a --app --environment -e --env --allow-different-app --allow-unknown-directory --allow --allow-all --force -f --help -h --version --verbose -v --telemetry --json" -- "$cur"))
@@ -899,6 +899,13 @@ complete -c ggt -n '__fish_seen_subcommand_from field' -l allow-all -d 'Enable a
 complete -c ggt -n '__ggt_needs_subcommand field -- --application -a --app --environment -e --env --allow' -a 'add' -d 'Add a field to an existing model'
 complete -c ggt -n '__ggt_needs_subcommand field -- --application -a --app --environment -e --env --allow' -a 'remove' -d 'Remove a field from a model'
 complete -c ggt -n '__ggt_needs_subcommand field -- --application -a --app --environment -e --env --allow' -a 'rename' -d 'Rename a field on a model'
+complete -c ggt -n '__ggt_seen_subcommand field -- add -- --application -a --app --environment -e --env --allow' -l required -d 'Mark the field as required'
+complete -c ggt -n '__ggt_seen_subcommand field -- add -- --application -a --app --environment -e --env --allow' -l unique -d 'Mark the field as unique'
+complete -c ggt -n '__ggt_seen_subcommand field -- add -- --application -a --app --environment -e --env --allow' -l metafield -d 'Store data from a Shopify metafield'
+complete -c ggt -n '__ggt_seen_subcommand field -- add -- --application -a --app --environment -e --env --allow' -l namespace -x -d 'Shopify metafield namespace. Required with --metafield.'
+complete -c ggt -n '__ggt_seen_subcommand field -- add -- --application -a --app --environment -e --env --allow' -l key -x -d 'Shopify metafield key. Only used with --metafield. Defaults to the field name.'
+complete -c ggt -n '__ggt_seen_subcommand field -- add -- --application -a --app --environment -e --env --allow' -l metafield-type -x -d 'Shopify metafield type. Required with --metafield.'
+complete -c ggt -n '__ggt_seen_subcommand field -- add -- --application -a --app --environment -e --env --allow' -l list -d 'Store a list of Shopify metafield values. Only used with --metafield.'
 complete -c ggt -n '__ggt_seen_subcommand field -- remove -- --application -a --app --environment -e --env --allow' -l force -s f -d 'Skip confirmation'
 complete -c ggt -n '__fish_seen_subcommand_from field' -l help -s h -d 'Show command help'
 complete -c ggt -n '__ggt_seen_subcommand field -- add -- --application -a --app --environment -e --env --allow' -l help -s h -d 'Show command help'
@@ -1718,7 +1725,14 @@ _ggt_field() {
             '--allow-different-app[Allow syncing with a different app]' \\
             '--allow-unknown-directory[Allow syncing to an existing directory]' \\
             '--allow[Enable allow flags (comma-separated)]:value: ' \\
-            '--allow-all[Enable all --allow-* flags]'
+            '--allow-all[Enable all --allow-* flags]' \\
+            '--required[Mark the field as required]' \\
+            '--unique[Mark the field as unique]' \\
+            '--metafield[Store data from a Shopify metafield]' \\
+            '--namespace[Shopify metafield namespace. Required with --metafield.]:value: ' \\
+            '--key[Shopify metafield key. Only used with --metafield. Defaults to the field name.]:value: ' \\
+            '--metafield-type[Shopify metafield type. Required with --metafield.]:value: ' \\
+            '--list[Store a list of Shopify metafield values. Only used with --metafield.]'
           ;;
         remove)
           _arguments \\

--- a/spec/commands/__snapshots__/root.spec.ts.snap
+++ b/spec/commands/__snapshots__/root.spec.ts.snap
@@ -1830,6 +1830,28 @@ FLAGS
         Environment to use. Defaults to the development environment. Production
         is read-only for most commands.
 
+      --key <value>
+        Shopify metafield key. Only used with --metafield. Defaults to the field
+        name.
+
+      --list
+        Store a list of Shopify metafield values. Only used with --metafield.
+
+      --metafield
+        Store data from a Shopify metafield
+
+      --metafield-type <value>
+        Shopify metafield type. Required with --metafield.
+
+      --namespace <value>
+        Shopify metafield namespace. Required with --metafield.
+
+      --required
+        Mark the field as required
+
+      --unique
+        Mark the field as unique
+
 ADDITIONAL FLAGS
       --allow <flag,...>
         Enable allow flags (comma-separated)
@@ -1852,6 +1874,7 @@ EXAMPLES
   $ ggt field add user/age:number
   $ ggt field add post/title:string
   $ ggt field add user/email:email
+  $ ggt field add shopifyProduct/spiciness:string --metafield --namespace custom --metafield-type single_line_text_field
 "
 `;
 
@@ -1867,12 +1890,20 @@ ARGUMENTS
 FLAGS
   -a, --app, --application <app>  Gadget app to use
   -e, --env, --environment <env>  Environment to use
+      --key <value>               Shopify metafield key. Only used with --metafield. Defaults to the field name.
+      --list                      Store a list of Shopify metafield values. Only used with --metafield.
+      --metafield                 Store data from a Shopify metafield
+      --metafield-type <value>    Shopify metafield type. Required with --metafield.
+      --namespace <value>         Shopify metafield namespace. Required with --metafield.
+      --required                  Mark the field as required
+      --unique                    Mark the field as unique
 
 EXAMPLES
   $ ggt field add post/published:boolean
   $ ggt field add user/age:number
   $ ggt field add post/title:string
   $ ggt field add user/email:email
+  $ ggt field add shopifyProduct/spiciness:string --metafield --namespace custom --metafield-type single_line_text_field
 
 Run ggt field add --help for more information.
 "

--- a/spec/commands/field.spec.ts
+++ b/spec/commands/field.spec.ts
@@ -82,6 +82,78 @@ describe("field", () => {
       expect(error).toBeInstanceOf(FlagError);
       expect(error.sprint()).toContain("is not a valid field definition");
     });
+
+    it("can add a required field", async () => {
+      nockEditResponse({
+        operation: CREATE_MODEL_FIELDS_MUTATION,
+        response: { data: { createModelFields: { remoteFilesVersion: "10", changed: [] } } },
+        expectVariables: {
+          path: "post",
+          fields: [{ name: "title", fieldType: "string", required: true }],
+        },
+      });
+
+      await runCommand(testCtx, field, "add", "post/title:string", "--required");
+    });
+
+    it("can add a unique field", async () => {
+      nockEditResponse({
+        operation: CREATE_MODEL_FIELDS_MUTATION,
+        response: { data: { createModelFields: { remoteFilesVersion: "10", changed: [] } } },
+        expectVariables: {
+          path: "post",
+          fields: [{ name: "title", fieldType: "string", unique: true }],
+        },
+      });
+
+      await runCommand(testCtx, field, "add", "post/title:string", "--unique");
+    });
+
+    it("can add a metafield", async () => {
+      nockEditResponse({
+        operation: CREATE_MODEL_FIELDS_MUTATION,
+        response: { data: { createModelFields: { remoteFilesVersion: "10", changed: [] } } },
+        expectVariables: {
+          path: "shopifyProduct",
+          fields: [
+            {
+              name: "spiciness",
+              fieldType: "string",
+              metafield: { namespace: "custom", key: "spiciness", type: "single_line_text_field", list: true },
+            },
+          ],
+        },
+      });
+
+      await runCommand(
+        testCtx,
+        field,
+        "add",
+        "shopifyProduct/spiciness:string",
+        "--metafield",
+        "--namespace",
+        "custom",
+        "--key",
+        "spiciness",
+        "--metafield-type",
+        "single_line_text_field",
+        "--list",
+      );
+    });
+
+    it("errors if --metafield without --namespace", async () => {
+      const error = await expectError(() => runCommand(testCtx, field, "add", "shopifyProduct/spiciness:string", "--metafield"));
+      expect(error).toBeInstanceOf(FlagError);
+      expect(error.sprint()).toContain("--namespace is required when using --metafield.");
+    });
+
+    it("errors if --metafield without --metafield-type", async () => {
+      const error = await expectError(() =>
+        runCommand(testCtx, field, "add", "shopifyProduct/spiciness:string", "--metafield", "--namespace", "custom"),
+      );
+      expect(error).toBeInstanceOf(FlagError);
+      expect(error.sprint()).toContain("--metafield-type is required when using --metafield.");
+    });
   });
 
   describe("remove", () => {

--- a/src/__generated__/edit.graphql
+++ b/src/__generated__/edit.graphql
@@ -126,6 +126,16 @@ type ContributorResult {
 input CreateModelFieldsInput {
   fieldType: String!
   name: String!
+  required: Boolean
+  unique: Boolean
+  metafield: CreateModelFieldsMetafieldInput
+}
+
+input CreateModelFieldsMetafieldInput {
+  namespace: String!
+  key: String
+  type: String!
+  list: Boolean
 }
 
 input CreateModelInput {

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -168,7 +168,17 @@ export type ContributorResult = {
 
 export type CreateModelFieldsInput = {
   fieldType: Scalars['String']['input'];
+  metafield?: InputMaybe<CreateModelFieldsMetafieldInput>;
   name: Scalars['String']['input'];
+  required?: InputMaybe<Scalars['Boolean']['input']>;
+  unique?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type CreateModelFieldsMetafieldInput = {
+  key?: InputMaybe<Scalars['String']['input']>;
+  list?: InputMaybe<Scalars['Boolean']['input']>;
+  namespace: Scalars['String']['input'];
+  type: Scalars['String']['input'];
 };
 
 export type CreateModelInput = {

--- a/src/commands/field.ts
+++ b/src/commands/field.ts
@@ -62,7 +62,17 @@ export default defineCommand({
         "ggt field add user/age:number",
         "ggt field add post/title:string",
         "ggt field add user/email:email",
+        "ggt field add shopifyProduct/spiciness:string --metafield --namespace custom --metafield-type single_line_text_field",
       ],
+      flags: {
+        "--required": { type: Boolean, description: "Mark the field as required" },
+        "--unique": { type: Boolean, description: "Mark the field as unique" },
+        "--metafield": { type: Boolean, description: "Store data from a Shopify metafield" },
+        "--namespace": { type: String, description: "Shopify metafield namespace. Required with --metafield." },
+        "--key": { type: String, description: "Shopify metafield key. Only used with --metafield. Defaults to the field name." },
+        "--metafield-type": { type: String, description: "Shopify metafield type. Required with --metafield." },
+        "--list": { type: Boolean, description: "Store a list of Shopify metafield values. Only used with --metafield." },
+      },
       positionals: [
         {
           name: "model/field:type",
@@ -99,11 +109,33 @@ export default defineCommand({
           throw new FlagError("Failed to add field, invalid field definition", { usageHint: false });
         }
 
+        let metafield: { namespace: string; key?: string; type: string; list?: boolean } | undefined;
+        if (flags["--metafield"]) {
+          const namespace = flags["--namespace"];
+          if (!namespace) throw new FlagError("--namespace is required when using --metafield.");
+          const metafieldType = flags["--metafield-type"];
+          if (!metafieldType) throw new FlagError("--metafield-type is required when using --metafield.");
+          metafield = {
+            namespace,
+            key: flags["--key"],
+            type: metafieldType,
+            list: flags["--list"] || undefined,
+          };
+        }
+
         await addFields(ctx, {
           syncJson,
           filesync,
           modelApiIdentifier: parsed.modelApiIdentifier,
-          fields: [{ name: parsed.fieldName, fieldType: parsed.fieldType }],
+          fields: [
+            {
+              name: parsed.fieldName,
+              fieldType: parsed.fieldType,
+              required: flags["--required"] || undefined,
+              unique: flags["--unique"] || undefined,
+              metafield,
+            },
+          ],
         });
 
         println({ ensureEmptyLineAbove: true, content: `Field ${colors.code(parsed.fieldName)} added successfully.` });

--- a/src/services/add/field.ts
+++ b/src/services/add/field.ts
@@ -89,7 +89,18 @@ export const addFields = async (
     syncJson: SyncJson;
     filesync: FileSync;
     modelApiIdentifier: string;
-    fields: Array<{ name: string; fieldType: string }>;
+    fields: Array<{
+      name: string;
+      fieldType: string;
+      required?: boolean;
+      unique?: boolean;
+      metafield?: {
+        namespace: string;
+        key?: string;
+        type: string;
+        list?: boolean;
+      };
+    }>;
   },
 ): Promise<AddFieldsResult> => {
   let result;
@@ -100,7 +111,13 @@ export const addFields = async (
         mutation: CREATE_MODEL_FIELDS_MUTATION,
         variables: {
           path: modelApiIdentifier,
-          fields: fields.map((f) => ({ name: f.name, fieldType: f.fieldType })),
+          fields: fields.map((f) => ({
+            name: f.name,
+            fieldType: f.fieldType,
+            ...(f.required !== undefined && { required: f.required }),
+            ...(f.unique !== undefined && { unique: f.unique }),
+            ...(f.metafield !== undefined && { metafield: f.metafield }),
+          })),
         },
       })
     ).createModelFields;


### PR DESCRIPTION
Adds three new flags to `ggt field add`:

- `--required` — mark the field as required
- `--unique` — mark the field as unique
- `--metafield` — link the field to a Shopify metafield (with `--namespace`, `--key`, `--metafield-type`, `--list`)

Matching `gadget` side PR: https://github.com/gadget-inc/gadget/pull/20495