### PR TITLE
Restore the dependabot auto-merge job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,20 @@ jobs:
         run: pnpm run test:integration
         env:
           INTEGRATION_TEST_TOKEN: ${{ secrets.INTEGRATION_TEST_TOKEN }}
+
+  dependabot:
+    needs: [lint, build, test]
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'gadget-inc/ggt'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v3
+      - name: Merge dependabot PR
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
The dependabot PR backlog is cleared: the lint toolchain incompatibility was fixed at the root in #2379, and every previously open dependabot PR is merged, superseded, or closed with a documented reason. Lint now stays green on regenerated lockfiles (verified against a from-scratch resolution on this branch), so auto-merging green dependabot PRs is safe again.

This re-adds the `dependabot` job to `ci.yml` exactly as it existed before #2379 removed it (byte-identical job block, extracted from the pre-removal commit).