### PR TITLE
Detect prototype-named paths in filesync key-presence checks

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -159,16 +159,6 @@
       "formComponents": [],
       "linkComponents": []
     },
-    "jsdoc": {
-      "ignorePrivate": false,
-      "ignoreInternal": false,
-      "ignoreReplacesDocs": true,
-      "overrideReplacesDocs": true,
-      "augmentsExtendsReplacesDocs": false,
-      "implementsReplacesDocs": false,
-      "exemptDestructuredRootsFromChecks": false,
-      "tagNamePreference": {}
-    },
     "vitest": {
       "typecheck": false
     }

--- a/spec/services/filesync/hashes.spec.ts
+++ b/spec/services/filesync/hashes.spec.ts
@@ -198,4 +198,11 @@ describe("isEqualHashes", () => {
     expect(isEqualHashes(testCtx, { "file.txt": { sha1 } }, { "file.txt": { sha1: otherSha1, permissions: 0o644 } })).toBe(false);
     expect(isEqualHashes(testCtx, { "file.txt": { sha1, permissions: 0o644 } }, { "file.txt": { sha1: otherSha1 } })).toBe(false);
   });
+
+  it("returns false when a path named like an Object.prototype property exists on only one side", () => {
+    const sha1 = randomUUID();
+
+    expect(isEqualHashes(testCtx, {}, { toString: { sha1 } })).toBe(false);
+    expect(isEqualHashes(testCtx, { toString: { sha1 } }, {})).toBe(false);
+  });
 });

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -145,7 +145,7 @@ const activateEnvironment = async (application: Application, envName: string): P
 
       const previousEnv = state.environment;
       state.environment = envName;
-      if (!(envName in state.environments)) {
+      if (!Object.hasOwn(state.environments, envName)) {
         state.environments[envName] = { filesVersion: "0" };
       }
 

--- a/src/services/filesync/hashes.ts
+++ b/src/services/filesync/hashes.ts
@@ -93,7 +93,7 @@ export const getNecessaryChanges = (
       continue;
     }
 
-    if (!(targetPath in source)) {
+    if (!Object.hasOwn(source, targetPath)) {
       // the targetPath doesn't exist in source, so it's been created
       const targetHash = target[targetPath];
       assert(targetHash, "targetHash should exist");
@@ -181,7 +181,7 @@ export const isEqualHashes = (ctx: Context, a: Hashes, b: Hashes): boolean => {
   }
 
   for (const bPath of Object.keys(b)) {
-    if (!(bPath in a)) {
+    if (!Object.hasOwn(a, bPath)) {
       ctx.log.debug("hashes are not equal", { path: bPath, aHash: undefined, bHash: b[bPath] });
       return false;
     }

--- a/src/services/filesync/sync-json.ts
+++ b/src/services/filesync/sync-json.ts
@@ -242,7 +242,7 @@ export class SyncJson {
       // update the state to the new environment
       previousEnvironment = state.environment;
       state.environment = appIdentity.environment.name;
-      if (!(appIdentity.environment.name in state.environments)) {
+      if (!Object.hasOwn(state.environments, appIdentity.environment.name)) {
         // the user has never synced to this environment before
         state.environments[appIdentity.environment.name] = { filesVersion: "0" };
       }


### PR DESCRIPTION
Two follow-ups from the review of the dependabot-backlog cleanup (#2379, #2380).

Key-presence checks on the plain-object `Hashes` and sync-state environment maps used truthiness or `in`, both of which report inherited `Object.prototype` properties as present. A file or environment literally named `toString` would be treated as already existing: `isEqualHashes` could report unequal trees as equal, and env activation could skip initializing sync state. Switched the four presence checks to `Object.hasOwn`, with a regression test on `isEqualHashes` using a `toString` path.

Also removes the `settings.jsdoc` block from `.oxlintrc.json` -- no jsdoc rules remain in the config, so the block configured nothing.