### PR TITLE
Pass secrets to CI when called from the cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
+    secrets: inherit
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
`cd.yml` calls the reusable `ci.yml` workflow without passing secrets, so `INTEGRATION_TEST_TOKEN` is absent on main pushes and all integration tests silently skip (verified in main-push run logs: 3 tests, 3 skipped, per matrix job). "CI green on main" therefore carries no integration signal.

Add `secrets: inherit` to the workflow call so post-merge CI runs exercise integration tests for real.

The `dependabot` auto-merge job inside `ci.yml` is unaffected: on a main push there is no `github.event.pull_request`, so its `if` stays false.