### PR TITLE
Fix the update banner changelog link to the ggt@<version> release tag

### DIFF
--- a/.changeset/fix-update-changelog-link.md
+++ b/.changeset/fix-update-changelog-link.md
@@ -1,0 +1,7 @@
+---
+"ggt": patch
+---
+
+Fix the changelog link in the update-available message
+
+The link now points to the GitHub release tagged `ggt@<version>`, matching the tags releases are published under.

--- a/spec/services/output/update.spec.ts
+++ b/spec/services/output/update.spec.ts
@@ -83,13 +83,13 @@ describe("warnIfUpdateAvailable", () => {
     await expect(shouldCheckForUpdate(testCtx)).resolves.toBeFalsy();
 
     expectStdout().toMatchInlineSnapshot(`
-      "╭──────────────────────────────────────────────────────────────────────╮
-      │                                                                      │
-      │                   Update available! 1.0.0 → 1.0.1                    │
-      │   Changelog: https://github.com/gadget-inc/ggt/releases/tag/v1.0.1   │
-      │                 Run "npm install -g ggt" to update.                  │
-      │                                                                      │
-      ╰──────────────────────────────────────────────────────────────────────╯
+      "╭───────────────────────────────────────────────────────────────────────────╮
+      │                                                                           │
+      │                      Update available! 1.0.0 → 1.0.1                      │
+      │   Changelog: https://github.com/gadget-inc/ggt/releases/tag/ggt%401.0.1   │
+      │                    Run "npm install -g ggt" to update.                    │
+      │                                                                           │
+      ╰───────────────────────────────────────────────────────────────────────────╯
       "
     `);
   });

--- a/src/services/output/update.ts
+++ b/src/services/output/update.ts
@@ -88,7 +88,7 @@ export const warnIfUpdateAvailable = async (ctx: Context): Promise<void> => {
       updateAvailable = semver.lt(packageJson.version, latest);
       updateMessage = sprint`
         Update available! ${colors.error(packageJson.version)} → ${colors.success(latest)}
-        Changelog: https://github.com/gadget-inc/ggt/releases/tag/v${latest}
+        Changelog: https://github.com/gadget-inc/ggt/releases/tag/ggt%40${latest}
         Run "npm install -g ${packageJson.name}" to update.
       `;
     }


### PR DESCRIPTION
The update-available banner links to a changelog page that does not exist: it builds the URL as `releases/tag/v<version>`, but ggt's GitHub releases are tagged `ggt@<version>` (e.g. https://github.com/gadget-inc/ggt/releases/tag/ggt%403.1.0), so the link 404s.

The banner now links to the `ggt%40<version>` tag form. Includes a patch changeset.